### PR TITLE
fix(ux): logic fixes from beta UX audit (Phase 3)

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -33,6 +33,7 @@ import '../screens/metronome_screen.dart';
 import '../screens/practice_placeholder_screen.dart';
 import '../screens/profile_screen.dart';
 import '../screens/setlists/create_setlist_screen.dart';
+import '../screens/setlists/setlist_view_screen.dart';
 import '../screens/setlists/setlists_list_screen.dart';
 import '../screens/songs/add_song_screen.dart';
 import '../screens/songs/models/song_form_data.dart';
@@ -424,6 +425,34 @@ List<RouteBase> _buildAppRoutes() {
                     );
                   },
                 ),
+                // 'create' is declared above the parameterized ':id' route
+                // for the same reason as the bands branch: go_router matches
+                // child routes in declaration order, so ':id' first would
+                // greedily match '/main/setlists/create' as a setlist with
+                // id="create".
+                GoRoute(
+                  path: ':id',
+                  name: 'setlist-view',
+                  builder: (context, state) {
+                    final setlist = state.extra as Setlist?;
+                    final scope =
+                        state.uri.queryParameters['scope'] ==
+                            SetlistStorageScope.band.name
+                        ? SetlistStorageScope.band
+                        : SetlistStorageScope.personal;
+                    final bandId = state.uri.queryParameters['bandId'];
+                    return SetlistRouteResolver(
+                      setlistId: state.pathParameters['id'],
+                      bandId: bandId,
+                      extra: setlist,
+                      builder: (live) => SetlistViewScreen(
+                        setlist: live,
+                        bandId: bandId,
+                        storageScope: scope,
+                      ),
+                    );
+                  },
+                ),
                 GoRoute(
                   path: ':id/edit',
                   name: 'edit-setlist',
@@ -667,7 +696,7 @@ class BandRouteResolver extends ConsumerWidget {
   }
 }
 
-/// Resolves the [Setlist] for the edit-setlist route.
+/// Resolves the [Setlist] for the setlist-view and edit-setlist routes.
 ///
 /// Same rationale as [BandRouteResolver]: `state.extra` is a navigation-time
 /// snapshot that go_router does not persist across restarts/deep links, and it

--- a/lib/screens/performance_sheet_screen.dart
+++ b/lib/screens/performance_sheet_screen.dart
@@ -15,6 +15,9 @@ import '../utils/chordpro.dart';
 import '../utils/snackbar.dart';
 import '../widgets/chord_chart_view.dart';
 import '../widgets/custom_app_bar.dart';
+import 'songs/chordpro_sync_controller.dart';
+import 'songs/components/import_lyrics_dialog.dart';
+import 'songs/song_editor_screen.dart';
 
 /// Full-screen, stage-readable lyrics+chords view for a song. Renders each
 /// section's ChordPro [Section.chordChart] as chords-over-lyrics, keeps the
@@ -210,6 +213,76 @@ class _PerformanceSheetScreenState extends ConsumerState<PerformanceSheetScreen>
     Navigator.of(context).pop();
   }
 
+  /// Opens the full-screen Song editor (live map ⇄ ChordPro sync) seeded from
+  /// the current performance sheet data.
+  Future<void> _openSongEditor() async {
+    final result = await Navigator.of(context).push<ImportedSong>(
+      MaterialPageRoute<ImportedSong>(
+        builder: (_) => SongEditorScreen(
+          title: widget.title,
+          sections: widget.sections,
+          artist: widget.song?.artist,
+          songKey: widget.songKey,
+          bpm: widget.bpm,
+          timeTop: widget.timeTop,
+        ),
+      ),
+    );
+    if (result == null || !mounted) return;
+    // Update sections from editor result; rebuild the rows
+    setState(() {
+      widget.sections.clear();
+      widget.sections.addAll(result.sections);
+      _recomputeRows();
+    });
+  }
+
+  /// Opens the import lyrics & chords sheet.
+  Future<void> _importLyrics() async {
+    final imported = await showModalBottomSheet<ImportedSong>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const ImportLyricsDialog(),
+    );
+    if (imported == null || imported.sections.isEmpty || !mounted) return;
+
+    var mode = ImportMode.replace;
+    if (widget.sections.isNotEmpty) {
+      final choice = await showDialog<ImportMode>(
+        context: context,
+        builder: (dctx) => AlertDialog(
+          title: const Text('You already have a song map'),
+          content: const Text(
+            'Replace it with the imported one, or append the imported sections?',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dctx),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(dctx, ImportMode.append),
+              child: const Text('Append'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(dctx, ImportMode.replace),
+              child: const Text('Replace'),
+            ),
+          ],
+        ),
+      );
+      if (choice == null || !mounted) return;
+      mode = choice;
+    }
+
+    // Apply imported sections
+    if (mode == ImportMode.replace) {
+      widget.sections.clear();
+    }
+    widget.sections.addAll(imported.sections);
+    setState(() => _recomputeRows());
+  }
+
   @override
   Widget build(BuildContext context) {
     final lyric =
@@ -251,7 +324,10 @@ class _PerformanceSheetScreenState extends ConsumerState<PerformanceSheetScreen>
         ],
       ),
       body: _rows.isEmpty
-          ? const _EmptyState()
+          ? _EmptyState(
+              onOpenEditor: _openSongEditor,
+              onImportLyrics: _importLyrics,
+            )
           : ListView.builder(
               controller: _scroll,
               padding: const EdgeInsets.all(MonoPulseSpacing.lg),
@@ -430,20 +506,48 @@ class _Row {
 }
 
 class _EmptyState extends StatelessWidget {
-  const _EmptyState();
+  const _EmptyState({
+    required this.onOpenEditor,
+    required this.onImportLyrics,
+  });
+
+  final VoidCallback onOpenEditor;
+  final VoidCallback onImportLyrics;
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(MonoPulseSpacing.xl),
-        child: Text(
-          'No lyrics or chords yet.\nAdd them to a section to see the '
-          'performance sheet.',
-          textAlign: TextAlign.center,
-          style: Theme.of(
-            context,
-          ).textTheme.bodyLarge?.copyWith(color: MonoPulseColors.textSecondary),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'No lyrics or chords yet.\nAdd them to a section to see the '
+              'performance sheet.',
+              textAlign: TextAlign.center,
+              style: Theme.of(
+                context,
+              ).textTheme.bodyLarge?.copyWith(color: MonoPulseColors.textSecondary),
+            ),
+            const SizedBox(height: MonoPulseSpacing.xl),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                ElevatedButton.icon(
+                  onPressed: onOpenEditor,
+                  icon: const Icon(Icons.edit_note),
+                  label: const Text('Open song editor'),
+                ),
+                const SizedBox(height: MonoPulseSpacing.md),
+                OutlinedButton.icon(
+                  onPressed: onImportLyrics,
+                  icon: const Icon(Icons.playlist_add),
+                  label: const Text('Import lyrics & chords'),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/setlists/setlist_view_screen.dart
+++ b/lib/screens/setlists/setlist_view_screen.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../models/setlist.dart';
+import '../../models/song.dart';
+import '../../providers/data/data_providers.dart';
+import '../../providers/data/metronome_provider.dart';
+import '../../providers/permissions_provider.dart';
+import '../../theme/mono_pulse_theme.dart';
+import '../../utils/snackbar.dart';
+import '../../widgets/custom_app_bar.dart';
+import '../../widgets/empty_state.dart';
+import '../../widgets/loading_indicator.dart';
+import '../../widgets/primary_action_bar.dart';
+import 'create_setlist_screen.dart' show SetlistStorageScope;
+
+/// Read-only detail view for a setlist (P1-7 fix).
+///
+/// Reached by tapping a setlist card on the Setlists tab. Previously a tap
+/// opened `CreateSetlistScreen` directly in edit mode ('Edit Setlist', drag
+/// handles, Save Changes) — one accidental tap away from an edit, and a dead
+/// end for read-only members. This screen shows the setlist's songs without
+/// any edit affordances; 'Edit' (app bar action, hidden for read-only users)
+/// is now a deliberate, separate step.
+class SetlistViewScreen extends ConsumerWidget {
+  const SetlistViewScreen({
+    required this.setlist,
+    super.key,
+    this.bandId,
+    this.storageScope = SetlistStorageScope.personal,
+  });
+
+  /// The setlist to display. Null while `SetlistRouteResolver` (in
+  /// app_router.dart) is still resolving the live setlist and has no
+  /// navigation-time snapshot to fall back to.
+  final Setlist? setlist;
+  final String? bandId;
+  final SetlistStorageScope storageScope;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final setlist = this.setlist;
+    if (setlist == null) {
+      return const Scaffold(body: Center(child: LoadingIndicator()));
+    }
+
+    final canEdit = ref.watch(canEditProvider);
+    final songsAsync = bandId == null
+        ? ref.watch(songsProvider)
+        : ref.watch(bandSongsProvider(bandId!));
+
+    return Scaffold(
+      appBar: CustomAppBar.build(
+        context,
+        title: setlist.name,
+        actions: [
+          if (canEdit)
+            TextButton(
+              onPressed: () => context.pushNamed(
+                'edit-setlist',
+                pathParameters: {'id': setlist.id},
+                extra: setlist,
+              ),
+              child: const Text('Edit'),
+            ),
+        ],
+      ),
+      body: songsAsync.when(
+        data: (songs) => _buildBody(setlist, songs),
+        loading: () => const LoadingIndicator(),
+        // A failed songs load shouldn't block the setlist details from
+        // showing; song rows just fall back to "unavailable".
+        error: (_, _) => _buildBody(setlist, const []),
+      ),
+      bottomNavigationBar: PrimaryActionBar(
+        label: 'Open in Metronome',
+        icon: Icons.av_timer,
+        onPressed: () => _openInMetronome(context, ref, setlist),
+      ),
+    );
+  }
+
+  Widget _buildBody(Setlist setlist, List<Song> allSongs) {
+    final songsById = {for (final song in allSongs) song.id: song};
+    final items = setlist.effectiveItems;
+
+    if (items.isEmpty) {
+      return const EmptyState(
+        icon: Icons.music_note,
+        message: 'No songs in this setlist',
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+      itemCount: items.length,
+      itemBuilder: (context, index) {
+        final song = songsById[items[index].songId];
+        return _SongRow(index: index, song: song);
+      },
+    );
+  }
+
+  /// Mirrors `SetlistsListScreen._openInMetronome`: loads the current songs,
+  /// hands them to the metronome queue, and pushes the metronome screen.
+  Future<void> _openInMetronome(
+    BuildContext context,
+    WidgetRef ref,
+    Setlist setlist,
+  ) async {
+    final allSongs = await ref.read(
+      bandId == null
+          ? songsProvider.future
+          : bandSongsProvider(bandId!).future,
+    );
+    final songs = allSongs.where((s) => setlist.songIds.contains(s.id)).toList();
+    if (!context.mounted) return;
+    final loaded = ref
+        .read(metronomeProvider.notifier)
+        .loadSetlistQueue(setlist, availableSongs: songs);
+    if (!loaded) {
+      showAppSnackBar(
+        context,
+        'This setlist is empty or has unavailable songs.',
+      );
+      return;
+    }
+    await context.pushNamed('metronome');
+  }
+}
+
+/// A single read-only song row. Visually mirrors the key/BPM badges used in
+/// `CreateSetlistScreen`'s editable rows, minus the drag handle and delete
+/// swipe — this screen never mutates the setlist.
+class _SongRow extends StatelessWidget {
+  const _SongRow({required this.index, required this.song});
+
+  final int index;
+  final Song? song;
+
+  @override
+  Widget build(BuildContext context) {
+    final song = this.song;
+    return Card(
+      margin: const EdgeInsets.only(bottom: MonoPulseSpacing.md),
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: MonoPulseColors.surfaceRaised,
+          child: Text(
+            '${index + 1}',
+            style: const TextStyle(
+              color: MonoPulseColors.textSecondary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+        title: Text(
+          song?.title ?? 'Unavailable song',
+          style: const TextStyle(color: MonoPulseColors.textPrimary),
+        ),
+        subtitle: song != null
+            ? Text(
+                song.artist,
+                style: const TextStyle(color: MonoPulseColors.textSecondary),
+              )
+            : null,
+        trailing: song == null
+            ? null
+            : Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: MonoPulseSpacing.md,
+                      vertical: MonoPulseSpacing.xs,
+                    ),
+                    decoration: BoxDecoration(
+                      color: MonoPulseColors.accentOrange10,
+                      borderRadius: BorderRadius.circular(
+                        MonoPulseRadius.small,
+                      ),
+                    ),
+                    child: Text(
+                      song.ourKey ?? '-',
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w700,
+                        color: MonoPulseColors.accentOrange,
+                      ),
+                    ),
+                  ),
+                  if (song.ourBPM != null) ...[
+                    const SizedBox(width: 8),
+                    Text(
+                      '${song.ourBPM}',
+                      style: const TextStyle(fontWeight: FontWeight.w700),
+                    ),
+                  ],
+                ],
+              ),
+      ),
+    );
+  }
+}

--- a/lib/screens/setlists/setlists_list_screen.dart
+++ b/lib/screens/setlists/setlists_list_screen.dart
@@ -144,8 +144,14 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
       songs,
     );
     if (index >= adapters.length) return;
-    // Open setlist for editing on tap
-    _handleEdit(index);
+    final setlist = adapters[index].setlist;
+    // Open the read-only view on tap (P1-7): editing is a deliberate,
+    // separate step from the view screen's Edit action, not one tap away.
+    context.pushNamed(
+      'setlist-view',
+      pathParameters: {'id': setlist.id},
+      extra: setlist,
+    );
   }
 
   void _handleEdit(int index) {

--- a/lib/screens/songs/songs_list_screen.dart
+++ b/lib/screens/songs/songs_list_screen.dart
@@ -14,6 +14,7 @@ import '../../providers/data/data_providers.dart';
 import '../../providers/permissions_provider.dart';
 import '../../services/song_library_merge_service.dart';
 import '../../theme/mono_pulse_theme.dart';
+import '../../utils/key_utils.dart';
 import '../../utils/snackbar.dart';
 import '../../widgets/app_filter_chip.dart';
 import '../../widgets/confirmation_dialog.dart';
@@ -73,7 +74,6 @@ final songsFilterSortProvider =
 
 /// State class for songs filter/sort.
 class SongsFilterSortState {
-
   const SongsFilterSortState({
     this.sortOption = SortOption.alphabetical,
     this.filterText = '',
@@ -334,9 +334,10 @@ class _SongsListScreenState extends ConsumerState<SongsListScreen>
         }
       }
 
-      // Key filter
-      if (keyFilter != null && song.ourKey != null) {
-        if (song.ourKey!.toLowerCase() != keyFilter.toLowerCase()) {
+      // Key filter (canonicalized: flats == sharps, case-insensitive; a
+      // song with no key never matches a specific key chip).
+      if (keyFilter != null && keyFilter.isNotEmpty) {
+        if (!keyMatchesFilter(song.ourKey, keyFilter)) {
           return false;
         }
       }
@@ -409,8 +410,35 @@ class _SongsListScreenState extends ConsumerState<SongsListScreen>
     ref.read(errorStateProvider.notifier).handleError(apiError);
   }
 
+  /// The 12 chromatic root notes (sharp spelling), used to build both the
+  /// major and minor key filter chips.
+  static const _keyRoots = [
+    'C',
+    'C#',
+    'D',
+    'D#',
+    'E',
+    'F',
+    'F#',
+    'G',
+    'G#',
+    'A',
+    'A#',
+    'B',
+  ];
+
   /// Show filter options bottom sheet.
   void _showFilterOptions() {
+    // Local (non-provider) UI state for the Major/Minor toggle. Declared
+    // here, outside the StatefulBuilder's rebuilding closure, so it
+    // survives setModalState calls. Defaults to whichever mode the current
+    // filter (if any) is already in.
+    var keyIsMinor =
+        canonicalKey(
+          ref.read(songsFilterSortProvider).keyFilter,
+        )?.endsWith('m') ??
+        false;
+
     showModalBottomSheet<void>(
       context: context,
       builder: (context) => StatefulBuilder(
@@ -418,129 +446,147 @@ class _SongsListScreenState extends ConsumerState<SongsListScreen>
           final state = ref.read(songsFilterSortProvider);
           final currentKey = state.keyFilter;
           final currentBpm = state.bpmFilter;
+          final canonicalCurrentKey = canonicalKey(currentKey);
 
-          return Container(
-            padding: const EdgeInsets.all(MonoPulseSpacing.lg),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Filter Options',
-                  style: MonoPulseTypography.titleLarge.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(height: 16),
-
-                // Key filter
-                const Text(
-                  'Key',
-                  style: TextStyle(fontWeight: FontWeight.w600),
-                ),
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: [
-                    AppFilterChip(
-                      label: 'All',
-                      selected: currentKey == null,
-                      onSelected: (_) {
-                        ref
-                            .read(songsFilterSortProvider.notifier)
-                            .setKeyFilter(null);
-                        setModalState(() {});
-                      },
+          return SingleChildScrollView(
+            child: Container(
+              padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Filter Options',
+                    style: MonoPulseTypography.titleLarge.copyWith(
+                      fontWeight: FontWeight.w700,
                     ),
-                    ...[
-                      'C',
-                      'C#',
-                      'D',
-                      'D#',
-                      'E',
-                      'F',
-                      'F#',
-                      'G',
-                      'G#',
-                      'A',
-                      'A#',
-                      'B',
-                    ].map(
-                      (key) => AppFilterChip(
-                        label: key,
-                        selected: currentKey == key,
+                  ),
+                  const SizedBox(height: 16),
+
+                  // Key filter
+                  const Text(
+                    'Key',
+                    style: TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: AppFilterChip(
+                          label: 'Major',
+                          selected: !keyIsMinor,
+                          onSelected: (_) {
+                            setModalState(() => keyIsMinor = false);
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: AppFilterChip(
+                          label: 'Minor',
+                          selected: keyIsMinor,
+                          onSelected: (_) {
+                            setModalState(() => keyIsMinor = true);
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      AppFilterChip(
+                        label: 'All',
+                        selected: currentKey == null,
                         onSelected: (_) {
                           ref
                               .read(songsFilterSortProvider.notifier)
-                              .setKeyFilter(key);
+                              .setKeyFilter(null);
                           setModalState(() {});
                         },
                       ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 16),
-
-                // BPM filter
-                const Text(
-                  'BPM',
-                  style: TextStyle(fontWeight: FontWeight.w600),
-                ),
-                const SizedBox(height: 8),
-                Row(
-                  children: [
-                    Expanded(
-                      child: DropdownButton<int?>(
-                        isExpanded: true,
-                        value: currentBpm,
-                        hint: const Text('Any BPM'),
-                        items: [
-                          const DropdownMenuItem(
-                            child: Text('Any BPM'),
-                          ),
-                          ...[60, 80, 100, 120, 140, 160, 180].map(
-                            (bpm) => DropdownMenuItem(
-                              value: bpm,
-                              child: Text('$bpm BPM'),
-                            ),
-                          ),
-                        ],
-                        onChanged: (value) {
-                          ref
-                              .read(songsFilterSortProvider.notifier)
-                              .setBpmFilter(value);
-                          setModalState(() {});
-                        },
-                      ),
-                    ),
-                    if (currentBpm != null)
-                      IconButton(
-                        icon: const Icon(Icons.clear),
-                        onPressed: () {
-                          ref
-                              .read(songsFilterSortProvider.notifier)
-                              .setBpmFilter(null);
-                          setModalState(() {});
-                        },
-                      ),
-                  ],
-                ),
-                const SizedBox(height: 16),
-
-                // Clear all filters button
-                SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton(
-                    onPressed: () {
-                      ref.read(songsFilterSortProvider.notifier).clearFilters();
-                      Navigator.pop(context);
-                    },
-                    child: const Text('Clear All Filters'),
+                      ..._keyRoots.map((root) {
+                        final value = keyIsMinor ? '${root}m' : root;
+                        final selected =
+                            canonicalCurrentKey != null &&
+                            canonicalCurrentKey == canonicalKey(value);
+                        return AppFilterChip(
+                          label: value,
+                          selected: selected,
+                          onSelected: (_) {
+                            ref
+                                .read(songsFilterSortProvider.notifier)
+                                .setKeyFilter(value);
+                            setModalState(() {});
+                          },
+                        );
+                      }),
+                    ],
                   ),
-                ),
-                const SizedBox(height: 8),
-              ],
+                  const SizedBox(height: 16),
+
+                  // BPM filter
+                  const Text(
+                    'BPM',
+                    style: TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: DropdownButton<int?>(
+                          isExpanded: true,
+                          value: currentBpm,
+                          hint: const Text('Any BPM'),
+                          items: [
+                            const DropdownMenuItem(child: Text('Any BPM')),
+                            ...[60, 80, 100, 120, 140, 160, 180].map(
+                              (bpm) => DropdownMenuItem(
+                                value: bpm,
+                                child: Text('$bpm BPM'),
+                              ),
+                            ),
+                          ],
+                          onChanged: (value) {
+                            ref
+                                .read(songsFilterSortProvider.notifier)
+                                .setBpmFilter(value);
+                            setModalState(() {});
+                          },
+                        ),
+                      ),
+                      if (currentBpm != null)
+                        IconButton(
+                          icon: const Icon(Icons.clear),
+                          onPressed: () {
+                            ref
+                                .read(songsFilterSortProvider.notifier)
+                                .setBpmFilter(null);
+                            setModalState(() {});
+                          },
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+
+                  // Clear all filters button
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton(
+                      onPressed: () {
+                        ref
+                            .read(songsFilterSortProvider.notifier)
+                            .clearFilters();
+                        Navigator.pop(context);
+                      },
+                      child: const Text('Clear All Filters'),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                ],
+              ),
             ),
           );
         },
@@ -556,7 +602,9 @@ class _SongsListScreenState extends ConsumerState<SongsListScreen>
     ref.watch(songQuickActionProvider);
     final exportSongs = songsAsync.value;
     final canExport = exportSongs != null && exportSongs.isNotEmpty;
-    final canEdit = ref.watch(canEditProvider); // false for the shared demo account
+    final canEdit = ref.watch(
+      canEditProvider,
+    ); // false for the shared demo account
 
     return StandardScreenScaffold(
       title: 'Songs',
@@ -957,5 +1005,4 @@ class _SongsListScreenState extends ConsumerState<SongsListScreen>
       });
     }
   }
-
 }

--- a/lib/utils/key_utils.dart
+++ b/lib/utils/key_utils.dart
@@ -1,0 +1,72 @@
+/// Musical key normalization for filter matching.
+///
+/// Stored/entered keys are free-form: sharps or flats ("C#", "Ab"), and
+/// minors as a lowercase (or mixed-case) root + trailing 'm' ("cm", "Abm").
+/// This canonicalizes any of those forms to a single comparable string so
+/// enharmonic equivalents (Ab == G#) and case variants (cm == Cm) match.
+library;
+
+/// Flat spelling -> canonical sharp spelling. Mirrors the mapping in
+/// `lib/utils/chordpro.dart`'s `_flatToSharp` (kept private there, so this
+/// is an independent copy for this module's own use).
+const _flatToSharp = {
+  'DB': 'C#',
+  'EB': 'D#',
+  'GB': 'F#',
+  'AB': 'G#',
+  'BB': 'A#',
+  'CB': 'B',
+  'FB': 'E',
+};
+
+const _validRoots = {'A', 'B', 'C', 'D', 'E', 'F', 'G'};
+
+/// Canonicalizes a musical key string for comparison.
+///
+/// - Uppercases the root note.
+/// - Maps flats to their canonical sharp spelling (Ab -> G#).
+/// - Preserves a trailing minor suffix ('m'), e.g. 'cm' -> 'Cm', 'abm' -> 'G#m'.
+/// - Returns `null` for `null`, empty, or unparseable input, so callers can
+///   treat those as "never matches a specific key filter".
+String? canonicalKey(String? key) {
+  if (key == null) return null;
+  final trimmed = key.trim();
+  if (trimmed.isEmpty) return null;
+
+  final isMinor = trimmed.length > 1 && trimmed.toUpperCase().endsWith('M');
+  final rootPart = isMinor ? trimmed.substring(0, trimmed.length - 1) : trimmed;
+  if (rootPart.isEmpty) return null;
+
+  final rootLetter = rootPart[0].toUpperCase();
+  if (!_validRoots.contains(rootLetter)) return null;
+
+  final accidental = rootPart.length > 1 ? rootPart.substring(1) : '';
+  String root;
+  if (accidental.isEmpty) {
+    root = rootLetter;
+  } else if (accidental == '#') {
+    root = '$rootLetter#';
+  } else if (accidental.toUpperCase() == 'B') {
+    final flatKey = '$rootLetter${accidental.toUpperCase()}';
+    final mapped = _flatToSharp[flatKey];
+    if (mapped == null) return null;
+    root = mapped;
+  } else {
+    // Unrecognized accidental (e.g. double sharp/flat) - can't normalize.
+    return null;
+  }
+
+  return isMinor ? '${root}m' : root;
+}
+
+/// Whether [songKey] matches the active [filterKey].
+///
+/// A null/empty [filterKey] means "no filter", so everything matches. A
+/// null/unparseable [songKey] never matches a real filter value - a song
+/// with no key shouldn't show up under a specific key chip.
+bool keyMatchesFilter(String? songKey, String? filterKey) {
+  if (filterKey == null || filterKey.isEmpty) return true;
+  final normalizedSong = canonicalKey(songKey);
+  if (normalizedSong == null) return false;
+  return normalizedSong == canonicalKey(filterKey);
+}

--- a/lib/widgets/unified_item/song_card_actions.dart
+++ b/lib/widgets/unified_item/song_card_actions.dart
@@ -99,7 +99,7 @@ mixin SongCardActions<T extends ConsumerStatefulWidget> on ConsumerState<T> {
   }) {
     // ponytail: chosen action missing on this song (no sheet/Spotify/bands)
     // falls back to Practice rather than an empty slot.
-    var quick = ref.read(songQuickActionProvider);
+    var quick = ref.watch(songQuickActionProvider);
     if (!_quickActionAvailable(quick, song, bands)) quick = 'practice';
     final (quickLabel, quickIcon) = quickActions[quick]!;
     return [
@@ -164,8 +164,11 @@ mixin SongCardActions<T extends ConsumerStatefulWidget> on ConsumerState<T> {
         ),
       ),
     );
-    if (choice != null) {
+    if (choice != null && choice != current) {
       await ref.read(songQuickActionProvider.notifier).set(choice);
+      if (!mounted) return;
+      final (label, _) = quickActions[choice]!;
+      showAppSnackBar(context, 'Quick action set to $label');
     }
   }
 

--- a/test/helpers/routed_test_harness.dart
+++ b/test/helpers/routed_test_harness.dart
@@ -192,6 +192,12 @@ GoRouter createRoutedTestRouter({
                     const TestRouteMarker('create-setlist'),
               ),
               GoRoute(
+                path: ':id',
+                name: 'setlist-view',
+                builder: (context, state) =>
+                    const TestRouteMarker('setlist-view'),
+              ),
+              GoRoute(
                 path: ':id/edit',
                 name: 'edit-setlist',
                 builder: (context, state) =>
@@ -229,6 +235,9 @@ Future<GoRouter> pumpRoutedTestApp(
   return router;
 }
 
+/// NOTE: this reports the last top-level `go` location; routes opened with
+/// `pushNamed` do NOT update it. For pushed routes assert the rendered
+/// `TestRouteMarker` text instead.
 Uri currentRouterUri(GoRouter router) {
   return router.routeInformationProvider.value.uri;
 }

--- a/test/screens/bands/my_bands_screen_test.dart
+++ b/test/screens/bands/my_bands_screen_test.dart
@@ -160,7 +160,8 @@ void main() {
       await tester.tap(find.widgetWithText(OutlinedButton, 'Join band'));
       await tester.pumpAndSettle();
 
-      expect(currentRouterUri(router).path, '/main/join-band');
+      // join-band is a pushed route: the reported URI goes stale; the
+      // rendered marker is the navigation signal.
       expect(find.text('route:join-band'), findsOneWidget);
     });
 
@@ -180,7 +181,8 @@ void main() {
       await tester.tap(find.text('Join band'));
       await tester.pumpAndSettle();
 
-      expect(currentRouterUri(router).path, '/main/join-band');
+      // join-band is a pushed route: the reported URI goes stale; the
+      // rendered marker is the navigation signal.
       expect(find.text('route:join-band'), findsOneWidget);
     });
 

--- a/test/screens/home_quick_actions_test.dart
+++ b/test/screens/home_quick_actions_test.dart
@@ -155,7 +155,8 @@ void main() {
       await tester.tap(find.text('Practice'));
       await tester.pumpAndSettle();
 
-      expect(currentRouterUri(router).path, '/main/practice');
+      // practice is a pushed route: the router's reported URI goes stale,
+      // so the rendered marker is the navigation signal.
       expect(find.text('route:practice'), findsOneWidget);
     });
   });

--- a/test/screens/login_screen_test.dart
+++ b/test/screens/login_screen_test.dart
@@ -213,9 +213,11 @@ void main() {
         await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
         await tester.pumpAndSettle();
 
-        expect(currentRouterUri(router).path, '/main/join-band');
-        expect(currentRouterUri(router).queryParameters['code'], 'ABC123');
+        // join-band is a pushed route: the router's reported URI goes stale,
+        // so assert the rendered marker (TestRouteMarker also prints the full
+        // uri, query included).
         expect(find.text('route:join-band'), findsOneWidget);
+        expect(find.text('uri:/main/join-band?code=ABC123'), findsOneWidget);
       },
     );
 

--- a/test/screens/performance_sheet_test.dart
+++ b/test/screens/performance_sheet_test.dart
@@ -1,5 +1,8 @@
 import 'package:flowgroove/models/section.dart';
+import 'package:flowgroove/models/song.dart';
 import 'package:flowgroove/screens/performance_sheet_screen.dart';
+import 'package:flowgroove/screens/songs/song_editor_screen.dart';
+import 'package:flowgroove/screens/songs/components/import_lyrics_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -41,5 +44,95 @@ void main() {
     await tester.pumpWidget(const SizedBox());
     await tester.pumpAndSettle();
     expect(find.byType(PerformanceSheetScreen), findsNothing);
+  });
+
+  testWidgets('empty state shows action buttons', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(400, 800)),
+            child: PerformanceSheetScreen(
+              title: 'Empty Song',
+              sections: [],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Verify empty state message is shown
+    expect(
+      find.text(
+        'No lyrics or chords yet.\nAdd them to a section to see the performance sheet.',
+      ),
+      findsOneWidget,
+    );
+
+    // Verify buttons are present
+    expect(find.text('Open song editor'), findsOneWidget);
+    expect(find.text('Import lyrics & chords'), findsOneWidget);
+
+    // Verify buttons are of correct types
+    expect(find.byType(ElevatedButton), findsOneWidget);
+    expect(find.byType(OutlinedButton), findsOneWidget);
+  });
+
+  testWidgets('open song editor button navigates to song editor', (tester) async {
+    final testSong = Song(
+      id: 'test-song-id',
+      title: 'Test Song',
+      artist: 'Test Artist',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(400, 800)),
+            child: PerformanceSheetScreen(
+              title: 'Empty Song',
+              sections: [],
+              song: testSong,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Tap the open song editor button
+    await tester.tap(find.text('Open song editor'));
+    await tester.pumpAndSettle();
+
+    // Verify navigation to SongEditorScreen
+    expect(find.byType(SongEditorScreen), findsOneWidget);
+  });
+
+  testWidgets('import lyrics button opens import dialog', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(400, 800)),
+            child: PerformanceSheetScreen(
+              title: 'Empty Song',
+              sections: [],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Tap the import lyrics button
+    await tester.tap(find.text('Import lyrics & chords'));
+    await tester.pumpAndSettle();
+
+    // Verify import dialog is shown
+    expect(find.byType(ImportLyricsDialog), findsOneWidget);
   });
 }

--- a/test/screens/setlists/setlist_view_screen_test.dart
+++ b/test/screens/setlists/setlist_view_screen_test.dart
@@ -1,0 +1,160 @@
+import 'package:flowgroove/models/setlist.dart';
+import 'package:flowgroove/models/song.dart';
+import 'package:flowgroove/providers/data/data_providers.dart';
+import 'package:flowgroove/providers/permissions_provider.dart';
+import 'package:flowgroove/screens/setlists/setlist_view_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../helpers/metronome_test_runtime.dart';
+import '../../helpers/mocks.dart';
+import '../../helpers/routed_test_harness.dart' show TestRouteMarker;
+
+void main() {
+  group('SetlistViewScreen', () {
+    late Setlist setlist;
+    late List<Song> songs;
+
+    setUp(() {
+      songs = [
+        MockDataHelper.createMockSong(
+          id: 's1',
+          title: 'First Song',
+          artist: 'Band A',
+          ourKey: 'C',
+          ourBPM: 120,
+        ),
+        MockDataHelper.createMockSong(
+          id: 's2',
+          title: 'Second Song',
+          artist: 'Band B',
+          ourKey: 'G',
+          ourBPM: 90,
+        ),
+      ];
+      setlist = MockDataHelper.createMockSetlist(
+        id: 'setlist-1',
+        name: 'Gig Setlist',
+        songIds: ['s1', 's2'],
+      );
+    });
+
+    /// Builds a minimal router with the view screen as home plus the two
+    /// named routes it can push to, so `context.pushNamed` calls resolve
+    /// without needing the full app router.
+    Future<GoRouter> pumpView(
+      WidgetTester tester, {
+      bool canEdit = true,
+    }) async {
+      final router = GoRouter(
+        initialLocation: '/view',
+        routes: [
+          GoRoute(
+            path: '/view',
+            name: 'view',
+            builder: (context, state) =>
+                SetlistViewScreen(setlist: setlist),
+          ),
+          GoRoute(
+            path: '/setlists/:id/edit',
+            name: 'edit-setlist',
+            builder: (context, state) =>
+                const TestRouteMarker('edit-setlist'),
+          ),
+          GoRoute(
+            path: '/metronome',
+            name: 'metronome',
+            builder: (context, state) => const TestRouteMarker('metronome'),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      final container = ProviderContainer(
+        overrides: [
+          songsProvider.overrideWith((ref) => Stream<List<Song>>.value(songs)),
+          setlistsProvider.overrideWith(
+            (ref) => Stream<List<Setlist>>.value([setlist]),
+          ),
+          canEditProvider.overrideWithValue(canEdit),
+          ...buildMetronomeTestOverrides(overrideMetronomeProvider: true),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      return router;
+    }
+
+    testWidgets('shows the setlist name as the title and lists its songs', (
+      tester,
+    ) async {
+      await pumpView(tester);
+
+      expect(find.text('Gig Setlist'), findsOneWidget);
+      expect(find.text('First Song'), findsOneWidget);
+      expect(find.text('Band A'), findsOneWidget);
+      expect(find.text('Second Song'), findsOneWidget);
+      expect(find.text('Band B'), findsOneWidget);
+      // Key/BPM badges, mirroring the editor's row visuals.
+      expect(find.text('C'), findsOneWidget);
+      expect(find.text('120'), findsOneWidget);
+      expect(find.text('G'), findsOneWidget);
+      expect(find.text('90'), findsOneWidget);
+    });
+
+    testWidgets('has no editing affordances — no Save Changes, no drag handles', (
+      tester,
+    ) async {
+      await pumpView(tester);
+
+      expect(find.text('Save Changes'), findsNothing);
+      expect(find.text('Edit Setlist'), findsNothing);
+      expect(find.byIcon(Icons.drag_handle), findsNothing);
+      expect(find.byType(Dismissible), findsNothing);
+    });
+
+    testWidgets('shows an Edit action that pushes the edit screen when canEdit', (
+      tester,
+    ) async {
+      await pumpView(tester);
+
+      expect(find.text('Edit'), findsOneWidget);
+
+      await tester.tap(find.text('Edit'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('route:edit-setlist'), findsOneWidget);
+    });
+
+    testWidgets('hides the Edit action when canEdit is false', (
+      tester,
+    ) async {
+      await pumpView(tester, canEdit: false);
+
+      expect(find.text('Edit'), findsNothing);
+    });
+
+    testWidgets('pushes the metronome screen from the primary action button', (
+      tester,
+    ) async {
+      await pumpView(tester);
+
+      expect(find.text('Open in Metronome'), findsOneWidget);
+
+      await tester.tap(find.text('Open in Metronome'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('route:metronome'), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/setlists/setlists_list_screen_test.dart
+++ b/test/screens/setlists/setlists_list_screen_test.dart
@@ -71,11 +71,20 @@ void main() {
         ),
       ];
 
+      // Cards count only songs that resolve against the library (P0-4 fix),
+      // so the fixture must actually contain s1..s3.
+      final songs = [
+        MockDataHelper.createMockSong(id: 's1', title: 'Song 1'),
+        MockDataHelper.createMockSong(id: 's2', title: 'Song 2'),
+        MockDataHelper.createMockSong(id: 's3', title: 'Song 3'),
+      ];
+
       await pumpRoutedTestApp(
         tester,
         initialLocation: '/main/setlists',
         overrides: overridesFor(
           setlists: Stream<List<Setlist>>.value(setlists),
+          songs: Stream<List<Song>>.value(songs),
         ),
       );
 
@@ -128,6 +137,33 @@ void main() {
 
       expect(find.text('No results found'), findsOneWidget);
       expect(find.text('Try searching for "missing"'), findsOneWidget);
+    });
+
+    testWidgets('tapping a setlist card opens the read-only view screen', (
+      tester,
+    ) async {
+      final setlists = [
+        MockDataHelper.createMockSetlist(id: '1', name: 'Gig Setlist'),
+      ];
+
+      await pumpRoutedTestApp(
+        tester,
+        initialLocation: '/main/setlists',
+        overrides: overridesFor(
+          setlists: Stream<List<Setlist>>.value(setlists),
+        ),
+      );
+
+      await tester.tap(find.text('Gig Setlist'));
+      await tester.pumpAndSettle();
+
+      // Note: pushNamed() from inside a StatefulShellBranch pushes onto the
+      // branch's own nested Navigator and doesn't update
+      // router.routeInformationProvider — the marker screen is the reliable
+      // signal that the right route rendered (same pattern used for the
+      // metronome push in songs_list_screen_test.dart).
+      expect(find.text('route:setlist-view'), findsOneWidget);
+      expect(find.text('route:edit-setlist'), findsNothing);
     });
 
     testWidgets('navigates to create setlist from FAB', (tester) async {

--- a/test/screens/songs/songs_list_screen_test.dart
+++ b/test/screens/songs/songs_list_screen_test.dart
@@ -245,7 +245,8 @@ void main() {
       await tester.pumpAndSettle();
 
       final metronomeState = container.read(metronomeProvider);
-      expect(currentRouterUri(router).path, '/main/metronome');
+      // metronome is a pushed route: the router's reported URI goes stale,
+      // so the rendered marker is the navigation signal.
       expect(find.text('route:metronome'), findsOneWidget);
       expect(metronomeState.loadedSong?.id, 'metronome-song');
       expect(metronomeState.bpm, 142);
@@ -438,6 +439,72 @@ void main() {
       );
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets(
+      'key filter matches a flat-stored key against its sharp chip (Ab == G#)',
+      (tester) async {
+        final songs = [
+          createTestSong(
+            id: '1',
+            title: 'Flat Song',
+            artist: 'A',
+            ourKey: 'Ab',
+          ),
+          createTestSong(id: '2', title: 'C Song', artist: 'B', ourKey: 'C'),
+          createTestSong(id: '3', title: 'No Key Song', artist: 'D'),
+        ];
+
+        await pumpRoutedTestApp(
+          tester,
+          initialLocation: '/main/songs',
+          overrides: overridesFor(songs: Stream<List<Song>>.value(songs)),
+        );
+
+        // Open the Key / BPM filter sheet and select the G# chip (major,
+        // the default toggle state).
+        await tester.tap(find.text('Key / BPM'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('G#'));
+        await tester.pumpAndSettle();
+
+        // Dismiss the bottom sheet via the barrier.
+        await tester.tapAt(const Offset(10, 10));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Flat Song'), findsOneWidget);
+        expect(find.text('C Song'), findsNothing);
+        // A song with no key must never match a specific key filter.
+        expect(find.text('No Key Song'), findsNothing);
+      },
+    );
+
+    testWidgets('Major/Minor toggle produces a minor-suffixed key filter', (
+      tester,
+    ) async {
+      final songs = [
+        createTestSong(id: '1', title: 'Minor Song', artist: 'A', ourKey: 'cm'),
+        createTestSong(id: '2', title: 'Major Song', artist: 'B', ourKey: 'C'),
+      ];
+
+      await pumpRoutedTestApp(
+        tester,
+        initialLocation: '/main/songs',
+        overrides: overridesFor(songs: Stream<List<Song>>.value(songs)),
+      );
+
+      await tester.tap(find.text('Key / BPM'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Minor'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cm'));
+      await tester.pumpAndSettle();
+
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Minor Song'), findsOneWidget);
+      expect(find.text('Major Song'), findsNothing);
     });
   });
 }

--- a/test/utils/key_utils_test.dart
+++ b/test/utils/key_utils_test.dart
@@ -1,0 +1,82 @@
+import 'package:flowgroove/utils/key_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('canonicalKey', () {
+    test('flats map to canonical sharps', () {
+      expect(canonicalKey('Ab'), 'G#');
+      expect(canonicalKey('Bb'), 'A#');
+      expect(canonicalKey('Db'), 'C#');
+      expect(canonicalKey('Eb'), 'D#');
+      expect(canonicalKey('Gb'), 'F#');
+    });
+
+    test('is case-insensitive', () {
+      expect(canonicalKey('ab'), canonicalKey('Ab'));
+      expect(canonicalKey('c'), canonicalKey('C'));
+    });
+
+    test('minor flats and mixed case all normalize the same way', () {
+      expect(canonicalKey('abm'), 'G#m');
+      expect(canonicalKey('Abm'), 'G#m');
+      expect(canonicalKey('ABM'), 'G#m');
+      expect(canonicalKey('abm'), canonicalKey('Abm'));
+      expect(canonicalKey('abm'), canonicalKey('G#m'));
+    });
+
+    test('lowercase-root minor form matches the Cm chip', () {
+      expect(canonicalKey('cm'), 'Cm');
+      expect(canonicalKey('cm'), canonicalKey('Cm'));
+    });
+
+    test('major and minor of the same root are distinct', () {
+      expect(canonicalKey('C'), isNot(equals(canonicalKey('Cm'))));
+      expect(canonicalKey('C'), 'C');
+      expect(canonicalKey('Cm'), 'Cm');
+    });
+
+    test('null and empty input return null', () {
+      expect(canonicalKey(null), isNull);
+      expect(canonicalKey(''), isNull);
+      expect(canonicalKey('   '), isNull);
+    });
+
+    test('unparseable input returns null', () {
+      expect(canonicalKey('H'), isNull);
+      expect(canonicalKey('Cx'), isNull);
+    });
+  });
+
+  group('keyMatchesFilter', () {
+    test('no filter matches everything', () {
+      expect(keyMatchesFilter('Ab', null), isTrue);
+      expect(keyMatchesFilter(null, null), isTrue);
+      expect(keyMatchesFilter(null, ''), isTrue);
+    });
+
+    test('a song with no key never matches a specific key filter', () {
+      expect(keyMatchesFilter(null, 'G#'), isFalse);
+      expect(keyMatchesFilter('', 'G#'), isFalse);
+    });
+
+    test('flat/sharp enharmonic equivalents match', () {
+      expect(keyMatchesFilter('Ab', 'G#'), isTrue);
+      expect(keyMatchesFilter('G#', 'Ab'), isTrue);
+    });
+
+    test('minor forms match regardless of casing/spelling', () {
+      expect(keyMatchesFilter('abm', 'G#m'), isTrue);
+      expect(keyMatchesFilter('Abm', 'G#m'), isTrue);
+      expect(keyMatchesFilter('cm', 'Cm'), isTrue);
+    });
+
+    test('major does not match minor of the same root', () {
+      expect(keyMatchesFilter('C', 'Cm'), isFalse);
+      expect(keyMatchesFilter('Cm', 'C'), isFalse);
+    });
+
+    test('different roots do not match', () {
+      expect(keyMatchesFilter('C', 'D'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Phase 3 of the UX-audit remediation. **Stacked on #102** (merge order #101 → #102 → this).

## Changes
- **P1-1** — Key filter now finds real songs: enharmonic normalization (`Ab`⇄`G#`), minor keys (`cm`) via a Major/Minor toggle, null-key songs excluded from key filters. New `lib/utils/key_utils.dart` + tests.
- **P1-2/H1** — quick-action picker shows a confirmation SnackBar and the pinned song-card icon reflects the chosen action.
- **P1-7** — setlists open in a new read-only `SetlistViewScreen` (Open in Metronome + gated Edit); editing is an explicit step.
- **P1-9** — performance-sheet empty state gains "Open song editor" / "Import lyrics & chords" CTAs.
- **P1-10** — no code change: a delete-confirmation dialog already existed (`song_constructor.dart:125`); AUDIT.md corrected.

## ⚠️ Honesty correction for #101/#102
Earlier "full suite green" claims were wrong: `flutter test | tail` masked exit codes, and 5 tests were failing — all asserting `currentRouterUri(...)` after `pushNamed` (go_router's routeInformationProvider goes stale for pushed routes; navigation itself was correct, verified via rendered route markers). This PR fixes all of them (marker-based assertions, documented on the helper) plus the setlist-count test fixture. Verified: **1938 passed, exit 0 with pipefail**. `flutter analyze`: 0 errors.

## Process notes
- Executed by 2 Sonnet + 3 Haiku agents; review caught: one agent editing the main repo instead of the worktree (patch transferred), one agent's work erased by another's `git stash` in the shared worktree (turned out behaviorally unnecessary), and both "pre-existing failure" claims being wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)