### PR TITLE
feat(ux): bottom-first navigation — Menu tab, thumb-zone Back, snackbar Undo

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -40,6 +40,7 @@ import '../screens/songs/models/song_form_data.dart';
 import '../screens/songs/song_duplicates_screen.dart';
 import '../screens/songs/songs_list_screen.dart';
 import '../screens/tuner_screen.dart';
+import 'branch_stack_observer.dart';
 
 /// Minimal auth surface needed by the app router.
 abstract class AuthRouterClient {
@@ -221,6 +222,7 @@ List<RouteBase> _buildAppRoutes() {
       branches: [
         // Home branch
         StatefulShellBranch(
+          observers: [BranchStackObserver(0)],
           routes: [
             GoRoute(
               path: '/main/home',
@@ -231,6 +233,7 @@ List<RouteBase> _buildAppRoutes() {
         ),
         // Songs branch
         StatefulShellBranch(
+          observers: [BranchStackObserver(1)],
           routes: [
             GoRoute(
               path: '/main/songs',
@@ -277,6 +280,7 @@ List<RouteBase> _buildAppRoutes() {
         ),
         // Bands branch
         StatefulShellBranch(
+          observers: [BranchStackObserver(2)],
           routes: [
             GoRoute(
               path: '/main/bands',
@@ -403,6 +407,7 @@ List<RouteBase> _buildAppRoutes() {
         ),
         // Setlists branch
         StatefulShellBranch(
+          observers: [BranchStackObserver(3)],
           routes: [
             GoRoute(
               path: '/main/setlists',
@@ -482,6 +487,7 @@ List<RouteBase> _buildAppRoutes() {
         ),
         // Profile branch
         StatefulShellBranch(
+          observers: [BranchStackObserver(4)],
           routes: [
             GoRoute(
               path: '/main/profile',

--- a/lib/router/branch_stack_observer.dart
+++ b/lib/router/branch_stack_observer.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/widgets.dart';
+
+/// Tracks how many page routes are stacked above each shell branch's root.
+///
+/// The shell needs to know "is the active branch showing a pushed child?"
+/// to switch its bottom bar between tabs mode and back/menu mode. The
+/// router's `currentConfiguration.uri` does NOT update for intra-branch
+/// pushes (verified on device and in tests), so we observe the branch
+/// navigators directly instead.
+///
+/// Only [PageRoute]s are counted: dialogs and bottom sheets are
+/// [PopupRoute]s pushed onto the same navigator and must not flip the bar.
+class BranchStackObserver extends NavigatorObserver {
+  BranchStackObserver(this.branchIndex);
+
+  final int branchIndex;
+
+  static const int branchCount = 5;
+
+  /// depths[i] = number of page routes above branch i's root (0 = at root).
+  static final ValueNotifier<List<int>> depths = ValueNotifier<List<int>>(
+    List<int>.filled(branchCount, 0),
+  );
+
+  int _pageRoutes = 0;
+
+  void _set() {
+    // didPush/didPop fire during navigation (often mid-build); notifying the
+    // shell synchronously triggers "setState() called during build". Defer
+    // the flush; it recomputes from _pageRoutes so stacked callbacks are
+    // idempotent.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final value = _pageRoutes > 0 ? _pageRoutes - 1 : 0;
+      if (depths.value[branchIndex] == value) return;
+      final next = List<int>.of(depths.value);
+      next[branchIndex] = value;
+      depths.value = next;
+    });
+  }
+
+  /// Test hook.
+  static void reset() {
+    depths.value = List<int>.filled(branchCount, 0);
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (route is PageRoute) {
+      _pageRoutes++;
+      _set();
+    }
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (route is PageRoute) {
+      _pageRoutes--;
+      _set();
+    }
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (route is PageRoute) {
+      _pageRoutes--;
+      _set();
+    }
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    // Page-for-page replace keeps the count; only adjust on type mismatch.
+    final wasPage = oldRoute is PageRoute;
+    final isPage = newRoute is PageRoute;
+    if (wasPage != isPage) {
+      _pageRoutes += isPage ? 1 : -1;
+      _set();
+    }
+  }
+}

--- a/lib/screens/bands/band_about_screen.dart
+++ b/lib/screens/bands/band_about_screen.dart
@@ -11,7 +11,9 @@ import '../../theme/mono_pulse_theme.dart';
 import '../../utils/member_label.dart';
 import '../../utils/music_role_icon.dart';
 import '../../utils/snackbar.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/custom_app_bar.dart';
+import '../../widgets/menu_items_scope.dart';
 import '../../widgets/role_picker_widget.dart';
 import '../../widgets/user_avatar.dart';
 
@@ -101,59 +103,45 @@ class _BandAboutScreenState extends ConsumerState<BandAboutScreen> {
     final canManageMembers = ref.watch(
       canManageBandMembersProvider(_band.id),
     );
-    return Scaffold(
-      appBar: CustomAppBar.build(
-        context,
+    // Pushed branch child: title + actions are published for the shell's
+    // bottom bar ([← Back] [title] [⋮ Menu]); the top bar is title-only.
+    return MenuScopePublisher(
+      data: MenuScopeData(
         title: 'About ${_band.name}',
-        menuItems: [
+        items: [
           if (_canEdit) ...[
-            PopupMenuItem<void>(
+            AppMenuItem(
+              icon: _isEditing ? Icons.close : Icons.edit_outlined,
+              label: _isEditing ? 'Cancel' : 'Edit',
               onTap: _toggleEdit,
-              child: Row(
-                children: [
-                  Icon(
-                    _isEditing ? Icons.close : Icons.edit_outlined,
-                    size: 20,
-                  ),
-                  const SizedBox(width: 12),
-                  Text(_isEditing ? 'Cancel' : 'Edit'),
-                ],
-              ),
             ),
-            PopupMenuItem<void>(
+            AppMenuItem(
+              icon: Icons.save_outlined,
+              label: 'Save',
               onTap: _saveChanges,
-              child: const Row(
-                children: [
-                  Icon(Icons.save_outlined, size: 20),
-                  SizedBox(width: 12),
-                  Text('Save'),
-                ],
-              ),
             ),
           ],
-          PopupMenuItem<void>(
+          AppMenuItem(
+            icon: Icons.share_outlined,
+            label: 'Share Band',
             onTap: () => _shareBand(context),
-            child: const Row(
-              children: [
-                Icon(Icons.share_outlined, size: 20),
-                SizedBox(width: 12),
-                Text('Share Band'),
-              ],
-            ),
           ),
         ],
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(MonoPulseSpacing.lg),
-        children: [
-          _buildBandInfo(),
-          const SizedBox(height: 24),
-          _buildDescriptionSection(),
-          const SizedBox(height: 24),
-          _buildTagsSection(),
-          const SizedBox(height: 24),
-          _buildMembersSection(canManageMembers),
-        ],
+      child: Scaffold(
+        appBar: CustomAppBar.build(context, title: 'About ${_band.name}'),
+        body: ListView(
+          padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+          children: [
+            _buildBandInfo(),
+            const SizedBox(height: 24),
+            _buildDescriptionSection(),
+            const SizedBox(height: 24),
+            _buildTagsSection(),
+            const SizedBox(height: 24),
+            _buildMembersSection(canManageMembers),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/bands/band_setlists_screen.dart
+++ b/lib/screens/bands/band_setlists_screen.dart
@@ -14,6 +14,7 @@ import '../../services/export/pdf_service.dart';
 import '../../services/export/setlist_export_sheet.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/snackbar.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_banner.dart' show ErrorBanner, ErrorBannerStyle;
 import '../../widgets/fab_variants.dart';
@@ -172,9 +173,10 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
       title: '${widget.band.name} Setlists',
       menuItems: canEdit
           ? [
-              PopupMenuItem<void>(
+              AppMenuItem(
+                icon: Icons.playlist_add,
+                label: 'Create Band Setlist',
                 onTap: _handleCreate,
-                child: const Text('Create Band Setlist'),
               ),
             ]
           : null,

--- a/lib/screens/bands/join_band_screen.dart
+++ b/lib/screens/bands/join_band_screen.dart
@@ -11,6 +11,7 @@ import '../../services/analytics_service.dart';
 import '../../services/secure_storage_service.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/snackbar.dart';
+import '../../widgets/bottom_nav_or_action_bar.dart';
 import '../../widgets/custom_app_bar.dart';
 
 class JoinBandScreen extends ConsumerStatefulWidget {
@@ -200,7 +201,18 @@ class _JoinBandScreenState extends ConsumerState<JoinBandScreen> {
         }
       },
       child: Scaffold(
-        appBar: CustomAppBar.buildSimple(context, title: 'Join Band'),
+        appBar: CustomAppBar.build(context, title: 'Join Band'),
+        // Root-pushed route (outside the shell): renders its own pushed-mode
+        // bottom bar. Back mirrors the PopScope's home-fallback logic above.
+        bottomNavigationBar: AppBottomBar.actions(
+          onBack: () {
+            if (context.canPop()) {
+              context.pop();
+            } else {
+              context.go('/main/home');
+            }
+          },
+        ),
         body: Stack(
           children: [
             // Main content

--- a/lib/screens/bands/my_bands_screen.dart
+++ b/lib/screens/bands/my_bands_screen.dart
@@ -11,6 +11,7 @@ import '../../providers/auth/error_provider.dart';
 import '../../providers/data/data_providers.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/snackbar.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/confirmation_dialog.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_banner.dart' show ErrorBanner, ErrorBannerStyle;
@@ -227,12 +228,14 @@ class _MyBandsScreenState extends ConsumerState<MyBandsScreen> {
       title: 'My Bands',
       showBackButton: false, // Hide back button for main tabs
       menuItems: [
-        PopupMenuItem<void>(
-          child: const Text('Create Band'),
+        AppMenuItem(
+          icon: Icons.add,
+          label: 'Create Band',
           onTap: () => context.goNamed('create-band'),
         ),
-        PopupMenuItem<void>(
-          child: const Text('Join band'),
+        AppMenuItem(
+          icon: Icons.group_add_outlined,
+          label: 'Join band',
           onTap: () => context.pushNamed('join-band'),
         ),
       ],

--- a/lib/screens/bands/the_band_screen.dart
+++ b/lib/screens/bands/the_band_screen.dart
@@ -16,6 +16,7 @@ import '../../services/avatar_function_service.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/analytics_debug.dart';
 import '../../utils/snackbar.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/dashboard_grid.dart';
 import '../../widgets/greeting_card.dart';
 import '../../widgets/quick_action_button.dart';
@@ -130,155 +131,51 @@ class _TheBandScreenState extends ConsumerState<TheBandScreen> {
     );
   }
 
-  /// Build menu items for 3-dots menu
-  List<PopupMenuEntry<dynamic>> _buildMenuItems() {
+  /// Build items for the bottom-bar Menu sheet. Rows with a null onTap render
+  /// disabled (permission-gated actions for non-editors/non-admins).
+  List<AppMenuItem> _buildMenuItems() {
     return [
-      // Edit Band Name
-      PopupMenuItem<void>(
-        enabled: _canEdit,
-        onTap: _canEdit ? () => _runAfterMenuCloses(_showEditNameDialog) : null,
-        child: Row(
-          children: [
-            const Icon(Icons.edit, size: 20),
-            const SizedBox(width: 12),
-            Text(
-              'Edit Band Name',
-              style: TextStyle(
-                color: _canEdit
-                    ? MonoPulseColors.textPrimary
-                    : MonoPulseColors.textTertiary,
-              ),
-            ),
-          ],
-        ),
+      AppMenuItem(
+        icon: Icons.edit,
+        label: 'Edit Band Name',
+        onTap: _canEdit ? _showEditNameDialog : null,
       ),
-
-      // Edit Description
-      PopupMenuItem<void>(
-        enabled: _canEdit,
-        onTap: _canEdit
-            ? () => _runAfterMenuCloses(_showEditDescriptionDialog)
-            : null,
-        child: Row(
-          children: [
-            const Icon(Icons.description, size: 20),
-            const SizedBox(width: 12),
-            Text(
-              'Edit Description',
-              style: TextStyle(
-                color: _canEdit
-                    ? MonoPulseColors.textPrimary
-                    : MonoPulseColors.textTertiary,
-              ),
-            ),
-          ],
-        ),
+      AppMenuItem(
+        icon: Icons.description,
+        label: 'Edit Description',
+        onTap: _canEdit ? _showEditDescriptionDialog : null,
       ),
-
-      const PopupMenuDivider(),
-
-      // Add Song
-      PopupMenuItem<void>(
-        onTap: () => _runAfterMenuCloses(_handleAddSong),
-        child: const Row(
-          children: [
-            Icon(Icons.add, size: 20),
-            SizedBox(width: 12),
-            Text('Add Song'),
-          ],
-        ),
+      AppMenuItem(
+        icon: Icons.add,
+        label: 'Add Song',
+        onTap: _handleAddSong,
       ),
-
-      // Add Setlist
-      PopupMenuItem<void>(
-        enabled: _canEdit,
-        onTap: _canEdit ? () => _runAfterMenuCloses(_handleAddSetlist) : null,
-        child: const Row(
-          children: [
-            Icon(Icons.playlist_add, size: 20),
-            SizedBox(width: 12),
-            Text('Add Setlist'),
-          ],
-        ),
+      AppMenuItem(
+        icon: Icons.playlist_add,
+        label: 'Add Setlist',
+        onTap: _canEdit ? _handleAddSetlist : null,
       ),
-
-      const PopupMenuDivider(),
-
-      // Edit Tags
-      PopupMenuItem<void>(
-        enabled: _canEdit,
-        onTap: _canEdit ? () => _runAfterMenuCloses(_handleEditTags) : null,
-        child: Row(
-          children: [
-            const Icon(Icons.label_outline, size: 20),
-            const SizedBox(width: 12),
-            Text(
-              'Edit Tags',
-              style: TextStyle(
-                color: _canEdit
-                    ? MonoPulseColors.textPrimary
-                    : MonoPulseColors.textTertiary,
-              ),
-            ),
-          ],
-        ),
+      AppMenuItem(
+        icon: Icons.label_outline,
+        label: 'Edit Tags',
+        onTap: _canEdit ? _handleEditTags : null,
       ),
-
-      // Edit Members
-      PopupMenuItem<void>(
-        enabled: _canEdit,
-        onTap: _canEdit ? () => _runAfterMenuCloses(_handleEditMembers) : null,
-        child: Row(
-          children: [
-            const Icon(Icons.people, size: 20),
-            const SizedBox(width: 12),
-            Text(
-              'Edit Members',
-              style: TextStyle(
-                color: _canEdit
-                    ? MonoPulseColors.textPrimary
-                    : MonoPulseColors.textTertiary,
-              ),
-            ),
-          ],
-        ),
+      AppMenuItem(
+        icon: Icons.people,
+        label: 'Edit Members',
+        onTap: _canEdit ? _handleEditMembers : null,
       ),
-
-      const PopupMenuDivider(),
-
-      // Change Band Avatar (admin only)
-      PopupMenuItem<void>(
-        enabled: _isBandAdmin,
-        onTap: _isBandAdmin
-            ? () => _runAfterMenuCloses(_handleChangeBandAvatar)
-            : null,
-        child: Row(
-          children: [
-            const Icon(Icons.image, size: 20),
-            const SizedBox(width: 12),
-            Text(
-              'Change Band Avatar',
-              style: TextStyle(
-                color: _isBandAdmin
-                    ? MonoPulseColors.textPrimary
-                    : MonoPulseColors.textTertiary,
-              ),
-            ),
-          ],
-        ),
+      AppMenuItem(
+        icon: Icons.image,
+        label: 'Change Band Avatar',
+        onTap: _isBandAdmin ? _handleChangeBandAvatar : null,
       ),
-
       // Remove Band Avatar (admin only, shown only when avatar exists)
       if (_liveBand().photoURL != null && _isBandAdmin)
-        PopupMenuItem<void>(
-          onTap: () => _runAfterMenuCloses(_handleRemoveBandAvatar),
-          child: const Row(
-            children: [
-              Icon(Icons.delete_outline, size: 20),
-              SizedBox(width: 12),
-              Text('Remove Band Avatar'),
-            ],
-          ),
+        AppMenuItem(
+          icon: Icons.delete_outline,
+          label: 'Remove Band Avatar',
+          onTap: _handleRemoveBandAvatar,
         ),
     ];
   }
@@ -401,13 +298,8 @@ class _TheBandScreenState extends ConsumerState<TheBandScreen> {
   }
 
   // ==================== Menu Actions ====================
-
-  void _runAfterMenuCloses(VoidCallback action) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      action();
-    });
-  }
+  // (The app menu sheet already closes itself and defers each action to the
+  // next frame, so the old _runAfterMenuCloses wrapper is gone.)
 
   /// Show dialog to edit band name
   Future<void> _showEditNameDialog() async {

--- a/lib/screens/main_shell.dart
+++ b/lib/screens/main_shell.dart
@@ -1,14 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../router/branch_stack_observer.dart';
 import '../theme/mono_pulse_theme.dart';
+import '../widgets/app_menu_sheet.dart';
+import '../widgets/bottom_nav_or_action_bar.dart';
 import '../widgets/demo_mode_banner.dart';
+import '../widgets/menu_items_scope.dart';
 
-/// One navigation destination, shared by the portrait [NavigationBar] and the
-/// landscape [NavigationRail] (Mono Pulse: "nav moves to a side rail").
-typedef _NavItem = ({IconData icon, IconData selectedIcon, String label});
-
-const List<_NavItem> _navItems = [
+/// The 4 branch tabs shown in root mode. Profile isn't a tab — its slot is
+/// replaced by Menu (tapping Menu opens a sheet with a Profile row instead of
+/// navigating there directly); the branch itself (index 4) is still reached
+/// via that row, or by any `context.go('/main/profile')` elsewhere.
+const List<AppNavItem> _tabs = [
   (icon: Icons.home_outlined, selectedIcon: Icons.home, label: 'Home'),
   (icon: Icons.music_note_outlined, selectedIcon: Icons.music_note, label: 'Songs'),
   (icon: Icons.groups_outlined, selectedIcon: Icons.groups, label: 'Bands'),
@@ -17,16 +21,35 @@ const List<_NavItem> _navItems = [
     selectedIcon: Icons.queue_music,
     label: 'Setlists',
   ),
-  (icon: Icons.person_outlined, selectedIcon: Icons.person, label: 'Profile'),
+];
+
+/// The 5 branch root locations, in branch-index order. Used both to clamp
+/// [StatefulNavigationShell.currentIndex] and to detect root vs. pushed mode:
+/// pushed ⇔ the router's current location isn't one of these.
+const List<String> _branchRootLocations = [
+  '/main/home',
+  '/main/songs',
+  '/main/bands',
+  '/main/setlists',
+  '/main/profile',
 ];
 
 /// Main application shell with adaptive navigation.
 /// Works with StatefulShellRoute.indexedStack for proper tab switching.
 ///
-/// Features:
-/// - Portrait: bottom navigation bar. Landscape: left navigation rail.
-/// - Single tap: Navigate to tab or show next screen in branch
-/// - Double tap: Navigate to root screen of each branch
+/// The bottom bar has two mutually exclusive modes (see [AppBottomBar]):
+/// - Root mode (on one of the 5 branch roots): the Home/Songs/Bands/Setlists
+///   tabs plus a Menu slot. Menu replaces the old Profile tab; it opens a
+///   bottom sheet (never navigates) with the current screen's contextual
+///   actions plus a Profile row.
+/// - Pushed mode (any pushed route inside the shell — a branch child like
+///   edit-song): `[← Back] [screen title] [⋮ Menu]`.
+///
+/// Root-pushed tool routes (Metronome/Tuner/Join Band) live outside the shell
+/// entirely (root navigator) — they render their own pushed-mode bar via
+/// their own scaffolds, not this one.
+///
+/// Portrait: bottom bar. Landscape: left rail (same two modes).
 class MainShell extends ConsumerStatefulWidget {
 
   const MainShell({required this.navigationShell, super.key});
@@ -40,12 +63,53 @@ class _MainShellState extends ConsumerState<MainShell> {
   DateTime? _lastTapTime;
   int? _lastTappedIndex;
 
+  // Pushed-mode detection needs BOTH signals:
+  // - BranchStackObserver depth: intra-branch pushes never update the
+  //   router's currentConfiguration.uri (device-verified), only the branch
+  //   navigator sees them.
+  // - URI check: deep entries (initialLocation/deep link straight to a child
+  //   route) build the child without firing observer pushes, so depth stays
+  //   0 while the URI correctly points below the branch root.
+  bool get _pushed {
+    final i = widget.navigationShell.currentIndex;
+    final depths = BranchStackObserver.depths.value;
+    if (i >= 0 && i < depths.length && depths[i] > 0) return true;
+    final uri = GoRouter.maybeOf(context)
+        ?.routerDelegate
+        .currentConfiguration
+        .uri
+        .toString();
+    return uri != null && !_branchRootLocations.contains(uri);
+  }
+
+  String get _branchRoot {
+    final i = widget.navigationShell.currentIndex;
+    return i >= 0 && i < _branchRootLocations.length
+        ? _branchRootLocations[i]
+        : _branchRootLocations.first;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    BranchStackObserver.depths.addListener(_onDepthsChange);
+  }
+
+  @override
+  void dispose() {
+    BranchStackObserver.depths.removeListener(_onDepthsChange);
+    super.dispose();
+  }
+
+  void _onDepthsChange() {
+    if (mounted) setState(() {});
+  }
+
   @override
   Widget build(BuildContext context) {
-    // The shell now has exactly 5 branches (Home/Songs/Bands/Setlists/Profile)
-    // matching _navItems — Metronome/Tuner/Join Band are pushed on top of the
-    // shell via the root navigator instead of being branches. Clamp kept as a
-    // harmless guard against out-of-range indices.
+    // The shell has exactly 5 branches (Home/Songs/Bands/Setlists/Profile)
+    // matching _branchRootLocations — Metronome/Tuner/Join Band are pushed on
+    // top of the shell via the root navigator instead of being branches.
     final currentIndex = widget.navigationShell.currentIndex;
     final safeIndex =
         currentIndex >= 0 && currentIndex < 5 ? currentIndex : 0;
@@ -73,34 +137,9 @@ class _MainShellState extends ConsumerState<MainShell> {
 
     return Scaffold(
       body: content,
-      bottomNavigationBar: DecoratedBox(
-        decoration: const BoxDecoration(
-          color: MonoPulseColors.black,
-          border: Border(
-            top: BorderSide(color: MonoPulseColors.borderSubtle),
-          ),
-        ),
-        child: SafeArea(
-          top: false,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: MonoPulseSpacing.sm,
-              vertical: MonoPulseSpacing.sm,
-            ),
-            child: Row(
-              children: [
-                for (var i = 0; i < _navItems.length; i++)
-                  Expanded(
-                    child: _NavTab(
-                      item: _navItems[i],
-                      selected: i == safeIndex,
-                      onTap: () => _onTap(context, i),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-        ),
+      bottomNavigationBar: ValueListenableBuilder<int>(
+        valueListenable: MenuScopeRegistry.revision,
+        builder: (context, _, _) => _buildBar(context, safeIndex),
       ),
     );
   }
@@ -109,24 +148,108 @@ class _MainShellState extends ConsumerState<MainShell> {
     return Container(
       width: 76,
       color: MonoPulseColors.blackSurface,
-      // Scrollable so the five tabs never overflow on a short landscape height.
+      // Scrollable so the tabs never overflow on a short landscape height.
       child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(vertical: MonoPulseSpacing.lg),
-        child: Column(
-          children: [
-            for (var i = 0; i < _navItems.length; i++)
+        child: ValueListenableBuilder<int>(
+          valueListenable: MenuScopeRegistry.revision,
+          builder: (context, _, _) => Column(
+            children: [
+              if (_pushed)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: MonoPulseSpacing.lg),
+                  child: NavTab(
+                    item: const (
+                      icon: Icons.arrow_back,
+                      selectedIcon: Icons.arrow_back,
+                      label: 'Back',
+                    ),
+                    selected: false,
+                    onTap: _handleBack,
+                  ),
+                )
+              else
+                for (var i = 0; i < _tabs.length; i++)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: MonoPulseSpacing.lg),
+                    child: NavTab(
+                      item: _tabs[i],
+                      selected: i == safeIndex,
+                      onTap: () => _onTap(context, i),
+                    ),
+                  ),
               Padding(
                 padding: const EdgeInsets.only(bottom: MonoPulseSpacing.lg),
-                child: _NavTab(
-                  item: _navItems[i],
-                  selected: i == safeIndex,
-                  onTap: () => _onTap(context, i),
+                child: NavTab(
+                  item: const (
+                    icon: Icons.more_horiz,
+                    selectedIcon: Icons.more_horiz,
+                    label: 'Menu',
+                  ),
+                  selected: !_pushed && safeIndex == 4,
+                  showBadge: _currentMenu()?.items.isNotEmpty ?? false,
+                  onTap: () => _openMenu(context),
                 ),
               ),
-          ],
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  Widget _buildBar(BuildContext context, int safeIndex) {
+    if (_pushed) {
+      final entry = _currentMenu();
+      return AppBottomBar.actions(
+        onBack: _handleBack,
+        // No title in the bar: the slim top app-bar title is the location
+        // signal; keeping it out of the bar avoids double titles (tools)
+        // and empty slots (screens without a registered scope).
+        primaryAction: entry?.primaryAction,
+        onMenu: (entry?.items.isNotEmpty ?? false)
+            ? () => _openMenu(context)
+            : null,
+      );
+    }
+
+    return AppBottomBar.tabs(
+      tabs: _tabs,
+      selectedIndex: safeIndex,
+      onTabTap: (i) => _onTap(context, i),
+      onMenuTap: () => _openMenu(context),
+      menuSelected: safeIndex == 4,
+      menuHasBadge: _currentMenu()?.items.isNotEmpty ?? false,
+    );
+  }
+
+  MenuScopeData? _currentMenu() => _pushed
+      // Deepest publisher above the branch root; null when the pushed screen
+      // has no menu (the bar then hides its ⋮ — never the root's menu).
+      ? MenuScopeRegistry.pushedEntryFor(_branchRoot)
+      : MenuScopeRegistry.forLocation(_branchRoot);
+
+  void _openMenu(BuildContext context) {
+    final entry = _currentMenu();
+    final fallbackTitle = !_pushed && widget.navigationShell.currentIndex >= 0
+        && widget.navigationShell.currentIndex < _tabs.length
+        ? _tabs[widget.navigationShell.currentIndex].label
+        : 'Menu';
+    showAppMenuSheet(
+      context,
+      title: entry?.title ?? fallbackTitle,
+      items: entry?.items ?? const [],
+      showProfileRow: !_pushed,
+      ref: ref,
+    );
+  }
+
+  void _handleBack() {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.go('/main/home');
+    }
   }
 
   void _onTap(BuildContext context, int index) {
@@ -153,88 +276,8 @@ class _MainShellState extends ConsumerState<MainShell> {
   /// Works on both web and mobile by directly navigating to the branch root URL.
   void _navigateToRootOfBranch(BuildContext context, int branchIndex) {
     // Direct URL navigation - most reliable for web
-    // These URLs correspond to the root of each StatefulShellRoute branch
-    switch (branchIndex) {
-      case 0: // Home
-        context.go('/main/home');
-      case 1: // Songs
-        context.go('/main/songs');
-      case 2: // Bands
-        context.go('/main/bands');
-      case 3: // Setlists
-        context.go('/main/setlists');
-      case 4: // Profile
-        context.go('/main/profile');
+    if (branchIndex >= 0 && branchIndex < _branchRootLocations.length) {
+      context.go(_branchRootLocations[branchIndex]);
     }
-  }
-}
-
-/// A single navigation tab (Mono Pulse): icon on top, label below. When
-/// selected the icon + label turn orange and the label gets a rounded pill
-/// background. Shared by the bottom bar (portrait) and the side rail
-/// (landscape). Keeps a ≥48px tap target.
-class _NavTab extends StatelessWidget {
-  const _NavTab({
-    required this.item,
-    required this.selected,
-    required this.onTap,
-  });
-
-  final _NavItem item;
-  final bool selected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final color = selected
-        ? MonoPulseColors.accentOrange
-        : MonoPulseColors.textTertiary;
-
-    final label = Text(
-      item.label,
-      maxLines: 1,
-      overflow: TextOverflow.ellipsis,
-      style: MonoPulseTypography.labelSmall.copyWith(
-        color: color,
-        fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
-      ),
-    );
-
-    return Semantics(
-      button: true,
-      selected: selected,
-      label: item.label,
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(MonoPulseRadius.medium),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(minHeight: 48),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(selected ? item.selectedIcon : item.icon, color: color, size: 22),
-              const SizedBox(height: MonoPulseSpacing.xs),
-              // Pill behind the label only when selected (per the doc's tab bar).
-              DecoratedBox(
-                decoration: BoxDecoration(
-                  color: selected
-                      ? MonoPulseColors.accentOrange15
-                      : MonoPulseColors.transparent,
-                  borderRadius: BorderRadius.circular(MonoPulseRadius.huge),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: MonoPulseSpacing.sm,
-                    vertical: MonoPulseSpacing.xxs,
-                  ),
-                  child: label,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/lib/screens/metronome_screen.dart
+++ b/lib/screens/metronome_screen.dart
@@ -10,6 +10,7 @@ import '../../providers/data/data_providers.dart';
 import '../../providers/data/metronome_provider.dart';
 import '../../router/app_router.dart';
 import '../../theme/mono_pulse_theme.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/tools/tool_scaffold.dart';
 import '../../widgets/tools/tool_transport_bar.dart';
 import '../widgets/metronome/metronome_sheets.dart';
@@ -121,260 +122,89 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
     );
   }
 
-  /// Builds menu items for the three dots menu
-  List<PopupMenuEntry<dynamic>> _buildMenuItems(
+  /// Builds items for the bottom-bar Menu sheet.
+  ///
+  /// Sound / Count-in / Ramp live here instead of on the main screen, so the
+  /// metronome stays clean (Mono Pulse: "main window stays clean"). Their
+  /// current values are folded into the row labels; Haptics is a live toggle
+  /// (`trailing` switch rebuilds in-sheet via Riverpod and does not close the
+  /// sheet, so several settings can be flipped in one visit).
+  List<AppMenuItem> _buildMenuItems(
     BuildContext context,
     MetronomeNotifier metronome,
     MetronomeState state, {
     required bool canEditSource,
   }) {
-    final items = <PopupMenuEntry<dynamic>>[];
-
-    // Concert Mode — full-screen stage view (Mono Pulse).
-    items.add(
-      PopupMenuItem<void>(
+    return [
+      // Concert Mode — full-screen stage view (Mono Pulse).
+      AppMenuItem(
+        icon: Icons.theaters_outlined,
+        label: 'Concert Mode',
         onTap: () => Navigator.of(context, rootNavigator: true).push(
           MaterialPageRoute<void>(
             builder: (_) => const ConcertModeScreen(),
             fullscreenDialog: true,
           ),
         ),
-        child: Row(
-          children: [
-            const Icon(
-              Icons.theaters_outlined,
-              color: MonoPulseColors.accentOrange,
-              size: 20,
-            ),
-            const SizedBox(width: MonoPulseSpacing.md),
-            Expanded(
-              child: Text(
-                'Concert Mode',
-                style: MonoPulseTypography.bodyMedium.copyWith(
-                  color: MonoPulseColors.textHighEmphasis,
-                ),
-              ),
-            ),
-          ],
-        ),
       ),
-    );
-
-    items.add(const PopupMenuDivider(height: 1));
-
-    // Sound / Count-in / Ramp live here instead of on the main screen, so the
-    // metronome stays clean (Mono Pulse: "main window stays clean").
-    PopupMenuItem<void> settingRow({
-      required IconData icon,
-      required String label,
-      required String trailing,
-      required bool active,
-      required VoidCallback onTap,
-    }) {
-      return PopupMenuItem<void>(
-        onTap: onTap,
-        child: Row(
-          children: [
-            Icon(
-              icon,
-              color: active
-                  ? MonoPulseColors.accentOrange
-                  : MonoPulseColors.textSecondary,
-              size: 20,
-            ),
-            const SizedBox(width: MonoPulseSpacing.md),
-            Expanded(
-              child: Text(
-                label,
-                style: MonoPulseTypography.bodyMedium.copyWith(
-                  color: MonoPulseColors.textHighEmphasis,
-                ),
-              ),
-            ),
-            Text(
-              trailing,
-              style: MonoPulseTypography.labelMedium.copyWith(
-                color: active
-                    ? MonoPulseColors.accentOrange
-                    : MonoPulseColors.textTertiary,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    items.add(
-      settingRow(
+      AppMenuItem(
         icon: Icons.graphic_eq,
-        label: 'Sound',
-        trailing: 'Click ›',
-        active: false,
+        label: 'Sound: Click',
         onTap: () => showSoundSheet(context),
       ),
-    );
-
-    items.add(const PopupMenuDivider(height: 1));
-
-    items.add(
-      PopupMenuItem<void>(
-        enabled: false,
-        height: 28,
-        child: Text(
-          'PRACTICE',
-          style: MonoPulseTypography.labelSmall.copyWith(
-            color: MonoPulseColors.textTertiary,
-            letterSpacing: 1.2,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-      ),
-    );
-
-    items.add(
-      settingRow(
+      AppMenuItem(
         icon: Icons.timer_outlined,
-        label: 'Count-in',
-        trailing: state.countInBars > 0 ? '${state.countInBars} bars ›' : 'Off ›',
-        active: state.countInBars > 0,
+        label: state.countInBars > 0
+            ? 'Count-in: ${state.countInBars} bars'
+            : 'Count-in: Off',
         onTap: () => showCountInSheet(context),
       ),
-    );
-
-    items.add(
-      settingRow(
+      AppMenuItem(
         icon: Icons.trending_up,
-        label: 'Ramp',
-        trailing: state.activeTempoRamp != null ? 'On ›' : 'Off ›',
-        active: state.activeTempoRamp != null,
+        label: state.activeTempoRamp != null ? 'Ramp: On' : 'Ramp: Off',
         onTap: () => showRampSheet(context),
       ),
-    );
-
-    items.add(const PopupMenuDivider(height: 1));
-
-    items.add(
-      PopupMenuItem<void>(
+      AppMenuItem(
+        icon: state.hapticsEnabled ? Icons.vibration : Icons.mobile_off,
+        label: 'Haptics',
         onTap: metronome.toggleHaptics,
-        child: Row(
-          children: [
-            Icon(
-              state.hapticsEnabled ? Icons.vibration : Icons.mobile_off,
-              color: state.hapticsEnabled
-                  ? MonoPulseColors.accentOrange
-                  : MonoPulseColors.textTertiary,
-              size: 20,
-            ),
-            const SizedBox(width: MonoPulseSpacing.md),
-            Expanded(
-              child: Text(
-                'Haptics',
-                style: MonoPulseTypography.bodyMedium.copyWith(
-                  color: MonoPulseColors.textHighEmphasis,
-                ),
-              ),
-            ),
-            Text(
-              state.hapticsEnabled ? 'On' : 'Off',
-              style: MonoPulseTypography.labelMedium.copyWith(
-                color: state.hapticsEnabled
-                    ? MonoPulseColors.accentOrange
-                    : MonoPulseColors.textTertiary,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ],
+        trailing: Consumer(
+          builder: (context, ref, _) {
+            final enabled = ref.watch(
+              metronomeProvider.select((s) => s.hapticsEnabled),
+            );
+            return Switch(
+              value: enabled,
+              activeThumbColor: MonoPulseColors.accentOrange,
+              onChanged: (_) =>
+                  ref.read(metronomeProvider.notifier).toggleHaptics(),
+            );
+          },
         ),
       ),
-    );
-
-    items.add(const PopupMenuDivider(height: 1));
-
-    // Save to Song (only shown when song is loaded)
-    if (state.activeSong != null) {
-      items.add(
-        PopupMenuItem<void>(
-          enabled: canEditSource,
+      // Save to Song (only shown when song is loaded)
+      if (state.activeSong != null) ...[
+        AppMenuItem(
+          icon: Icons.edit_outlined,
+          label: 'Edit Song',
           onTap: canEditSource
               ? () => _navigateToEditSong(context, state)
               : null,
-          child: Row(
-            children: [
-              const Icon(
-                Icons.edit_outlined,
-                color: MonoPulseColors.accentOrange,
-                size: 20,
-              ),
-              const SizedBox(width: MonoPulseSpacing.md),
-              Expanded(
-                child: Text(
-                  'Edit Song',
-                  style: MonoPulseTypography.bodyMedium.copyWith(
-                    color: MonoPulseColors.textHighEmphasis,
-                  ),
-                ),
-              ),
-            ],
-          ),
         ),
-      );
-
-      items.add(
-        PopupMenuItem<void>(
-          enabled: canEditSource,
+        AppMenuItem(
+          icon: Icons.save_outlined,
+          label: "Save to '${state.activeSong!.title}'",
           onTap: canEditSource
               ? () => _saveMetronomeToSong(context, metronome, state)
               : null,
-          child: Row(
-            children: [
-              const Icon(
-                Icons.save_outlined,
-                color: MonoPulseColors.accentOrange,
-                size: 20,
-              ),
-              const SizedBox(width: MonoPulseSpacing.md),
-              Expanded(
-                child: Text(
-                  "Save to '${state.activeSong!.title}'",
-                  style: MonoPulseTypography.bodyMedium.copyWith(
-                    color: MonoPulseColors.textHighEmphasis,
-                  ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            ],
-          ),
         ),
-      );
-    }
-
-    // Save New Song
-    items.add(
-      PopupMenuItem<void>(
-        enabled: canEditSource,
+      ],
+      AppMenuItem(
+        icon: Icons.add_circle_outline,
+        label: 'Save New Song',
         onTap: canEditSource ? () => _navigateToSaveSong(context, state) : null,
-        child: Row(
-          children: [
-            const Icon(
-              Icons.add_circle_outline,
-              color: MonoPulseColors.accentOrange,
-              size: 20,
-            ),
-            const SizedBox(width: MonoPulseSpacing.md),
-            Text(
-              'Save New Song',
-              style: MonoPulseTypography.bodyMedium.copyWith(
-                color: MonoPulseColors.textHighEmphasis,
-              ),
-            ),
-          ],
-        ),
       ),
-    );
-
-    return items;
+    ];
   }
 
   /// Save current metronome settings to the loaded song
@@ -582,5 +412,3 @@ class _MetronomeTransport extends ConsumerWidget {
     );
   }
 }
-
-

--- a/lib/screens/performance_sheet_screen.dart
+++ b/lib/screens/performance_sheet_screen.dart
@@ -13,6 +13,7 @@ import '../services/wakelock_controller.dart';
 import '../theme/mono_pulse_theme.dart';
 import '../utils/chordpro.dart';
 import '../utils/snackbar.dart';
+import '../widgets/app_menu_sheet.dart';
 import '../widgets/chord_chart_view.dart';
 import '../widgets/custom_app_bar.dart';
 import 'songs/chordpro_sync_controller.dart';
@@ -293,33 +294,25 @@ class _PerformanceSheetScreenState extends ConsumerState<PerformanceSheetScreen>
     );
 
     return Scaffold(
-      // Classic 3-dot menu like every other screen (#79); transpose lives in
-      // the bottom bar next to the scroll transport.
+      // Pushed imperatively (Navigator.push), so it lives outside go_router
+      // and can't use the shell's bottom bar — back + menu stay in the top
+      // bar here (menu opens the app menu sheet). Transpose lives in the
+      // bottom bar next to the scroll transport.
       appBar: CustomAppBar.build(
         context,
         title: widget.title,
         onBack: _handleBack,
         menuItems: [
-          PopupMenuItem<void>(
+          AppMenuItem(
+            icon: Icons.picture_as_pdf_outlined,
+            label: 'Export PDF',
             onTap: _exportPdf,
-            child: const Row(
-              children: [
-                Icon(Icons.picture_as_pdf_outlined, size: 20),
-                SizedBox(width: MonoPulseSpacing.sm),
-                Text('Export PDF'),
-              ],
-            ),
           ),
           if (widget.song case final song?)
-            PopupMenuItem<void>(
+            AppMenuItem(
+              icon: Icons.description_outlined,
+              label: 'Export ChordPro',
               onTap: () => _exportChordPro(song),
-              child: const Row(
-                children: [
-                  Icon(Icons.description_outlined, size: 20),
-                  SizedBox(width: MonoPulseSpacing.sm),
-                  Text('Export ChordPro'),
-                ],
-              ),
             ),
         ],
       ),

--- a/lib/screens/setlists/create_setlist_screen.dart
+++ b/lib/screens/setlists/create_setlist_screen.dart
@@ -554,11 +554,29 @@ class _CreateSetlistScreenState extends ConsumerState<CreateSetlistScreen> {
                           color: MonoPulseColors.textPrimary,
                         ),
                       ),
-                      onDismissed: (_) => setState(() {
-                        _selectedSongs.removeAt(index);
-                        _selectedItems.removeAt(index);
-                        _markAsChanged();
-                      }),
+                      onDismissed: (_) {
+                        final removedSong = _selectedSongs[index];
+                        final removedItem = _selectedItems[index];
+                        setState(() {
+                          _selectedSongs.removeAt(index);
+                          _selectedItems.removeAt(index);
+                          _markAsChanged();
+                        });
+
+                        // Show snackbar with undo action
+                        showAppSnackBar(
+                          context,
+                          'Removed "${removedSong.title}"',
+                          actionLabel: 'Undo',
+                          onAction: () {
+                            setState(() {
+                              _selectedSongs.insert(index, removedSong);
+                              _selectedItems.insert(index, removedItem);
+                              _markAsChanged();
+                            });
+                          },
+                        );
+                      },
                       child: Card(
                         margin: const EdgeInsets.only(
                           bottom: MonoPulseSpacing.md,

--- a/lib/screens/setlists/setlist_view_screen.dart
+++ b/lib/screens/setlists/setlist_view_screen.dart
@@ -9,10 +9,12 @@ import '../../providers/data/metronome_provider.dart';
 import '../../providers/permissions_provider.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/snackbar.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/custom_app_bar.dart';
+import '../../widgets/custom_button.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/loading_indicator.dart';
-import '../../widgets/primary_action_bar.dart';
+import '../../widgets/menu_items_scope.dart';
 import 'create_setlist_screen.dart' show SetlistStorageScope;
 
 /// Read-only detail view for a setlist (P1-7 fix).
@@ -50,33 +52,41 @@ class SetlistViewScreen extends ConsumerWidget {
         ? ref.watch(songsProvider)
         : ref.watch(bandSongsProvider(bandId!));
 
-    return Scaffold(
-      appBar: CustomAppBar.build(
-        context,
+    // Publishes into the shell's bottom bar (this is a pushed branch child):
+    // the title slot is replaced by the "Open in Metronome" primary action
+    // (bar becomes [← Back] [Open in Metronome] [⋮]); Edit — previously an
+    // app-bar TextButton — moved into the Menu sheet.
+    return MenuScopePublisher(
+      data: MenuScopeData(
         title: setlist.name,
-        actions: [
+        items: [
           if (canEdit)
-            TextButton(
-              onPressed: () => context.pushNamed(
+            AppMenuItem(
+              icon: Icons.edit_outlined,
+              label: 'Edit Setlist',
+              onTap: () => context.pushNamed(
                 'edit-setlist',
                 pathParameters: {'id': setlist.id},
                 extra: setlist,
               ),
-              child: const Text('Edit'),
             ),
         ],
+        primaryAction: CustomButton(
+          label: 'Open in Metronome',
+          icon: Icons.av_timer,
+          size: ButtonSize.small,
+          onPressed: () => _openInMetronome(context, ref, setlist),
+        ),
       ),
-      body: songsAsync.when(
-        data: (songs) => _buildBody(setlist, songs),
-        loading: () => const LoadingIndicator(),
-        // A failed songs load shouldn't block the setlist details from
-        // showing; song rows just fall back to "unavailable".
-        error: (_, _) => _buildBody(setlist, const []),
-      ),
-      bottomNavigationBar: PrimaryActionBar(
-        label: 'Open in Metronome',
-        icon: Icons.av_timer,
-        onPressed: () => _openInMetronome(context, ref, setlist),
+      child: Scaffold(
+        appBar: CustomAppBar.build(context, title: setlist.name),
+        body: songsAsync.when(
+          data: (songs) => _buildBody(setlist, songs),
+          loading: () => const LoadingIndicator(),
+          // A failed songs load shouldn't block the setlist details from
+          // showing; song rows just fall back to "unavailable".
+          error: (_, _) => _buildBody(setlist, const []),
+        ),
       ),
     );
   }

--- a/lib/screens/setlists/setlists_list_screen.dart
+++ b/lib/screens/setlists/setlists_list_screen.dart
@@ -12,6 +12,7 @@ import '../../services/export/pdf_service.dart';
 import '../../services/export/setlist_export_sheet.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/snackbar.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_banner.dart' show ErrorBanner, ErrorBannerStyle;
 import '../../widgets/fab_variants.dart';
@@ -134,6 +135,21 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
       await ref
           .read(firestoreProvider)
           .deleteSetlist(setlist.id, uid: user.uid);
+
+      // Show snackbar with undo action
+      if (mounted) {
+        showAppSnackBar(
+          context,
+          'Setlist "${setlist.name}" deleted',
+          actionLabel: 'Undo',
+          onAction: () async {
+            // Re-save the setlist via the same service call used by _saveManualOrder
+            await ref
+                .read(firestoreProvider)
+                .saveSetlist(setlist, uid: user.uid);
+          },
+        );
+      }
     }
   }
 
@@ -180,8 +196,9 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
       showBackButton: false, // Hide back button for main tabs
       menuItems: [
         if (canEdit)
-          PopupMenuItem<void>(
-            child: const Text('Create Setlist'),
+          AppMenuItem(
+            icon: Icons.playlist_add,
+            label: 'Create Setlist',
             onTap: () => context.goNamed('create-setlist'),
           ),
       ],

--- a/lib/screens/settings/api_access_screen.dart
+++ b/lib/screens/settings/api_access_screen.dart
@@ -118,7 +118,14 @@ class _ApiAccessScreenState extends State<ApiAccessScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: CustomAppBar.build(context, title: 'AI access (MCP)'),
+      // Pushed imperatively from Profile (Navigator.push), so it lives
+      // outside go_router and the shell's bottom bar can't serve it — keep an
+      // explicit back button in the top bar.
+      appBar: CustomAppBar.build(
+        context,
+        title: 'AI access (MCP)',
+        onBack: () => Navigator.of(context).pop(),
+      ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _createKey,
         icon: const Icon(Icons.add),

--- a/lib/screens/songs/add_song_screen.dart
+++ b/lib/screens/songs/add_song_screen.dart
@@ -17,8 +17,10 @@ import '../../utils/snackbar.dart';
 import '../../utils/lyrics_sections.dart';
 import '../../utils/song_tags.dart';
 import '../../utils/suggestion_links.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/custom_app_bar.dart';
 import '../../widgets/error_banner.dart' show ErrorBanner;
+import '../../widgets/menu_items_scope.dart';
 import '../../widgets/primary_action_bar.dart';
 import '../../widgets/suggestion_selection_dialog.dart';
 import '../performance_sheet_screen.dart';
@@ -493,12 +495,15 @@ class _AddSongScreenState extends ConsumerState<AddSongScreen>
           await _autoSave();
         }
       },
-      child: Scaffold(
-        appBar: CustomAppBar.build(
-          context,
+      // Pushed branch child: title + actions are published for the shell's
+      // bottom bar ([← Back] [title] [⋮ Menu]); the top bar is title-only.
+      child: MenuScopePublisher(
+        data: MenuScopeData(
           title: _isEditing ? 'Edit Song' : 'Add Song',
-          menuItems: [
-            PopupMenuItem<void>(
+          items: [
+            AppMenuItem(
+              icon: Icons.queue_music,
+              label: 'Performance sheet',
               onTap: () => Navigator.of(context).push(
                 MaterialPageRoute<void>(
                   builder: (_) => PerformanceSheetScreen(
@@ -512,35 +517,23 @@ class _AddSongScreenState extends ConsumerState<AddSongScreen>
                   ),
                 ),
               ),
-              child: const Row(
-                children: [
-                  Icon(Icons.queue_music),
-                  SizedBox(width: 8),
-                  Text('Performance sheet'),
-                ],
-              ),
             ),
-            PopupMenuItem<void>(
+            AppMenuItem(
+              icon: Icons.edit_note,
+              label: 'Song editor (map + ChordPro)',
               onTap: _openSongEditor,
-              child: const Row(
-                children: [
-                  Icon(Icons.edit_note),
-                  SizedBox(width: 8),
-                  Text('Song editor (map + ChordPro)'),
-                ],
-              ),
             ),
-            PopupMenuItem<void>(
+            AppMenuItem(
+              icon: Icons.content_paste,
+              label: 'Import lyrics & chords',
               onTap: _importLyrics,
-              child: const Row(
-                children: [
-                  Icon(Icons.content_paste),
-                  SizedBox(width: 8),
-                  Text('Import lyrics & chords'),
-                ],
-              ),
             ),
           ],
+        ),
+        child: Scaffold(
+        appBar: CustomAppBar.build(
+          context,
+          title: _isEditing ? 'Edit Song' : 'Add Song',
         ),
         body: !_formReady
             ? const SizedBox.shrink()
@@ -652,6 +645,7 @@ class _AddSongScreenState extends ConsumerState<AddSongScreen>
           label: _isEditing ? 'Save Changes' : 'Save Song',
           onPressed: isSaving ? null : _saveSong,
           isLoading: isSaving,
+        ),
         ),
       ),
     );

--- a/lib/screens/songs/components/song_constructor/song_constructor.dart
+++ b/lib/screens/songs/components/song_constructor/song_constructor.dart
@@ -6,6 +6,7 @@ import 'package:uuid/uuid.dart';
 
 import '../../../../../models/section.dart';
 import '../../../../../theme/mono_pulse_theme.dart';
+import '../../../../../utils/snackbar.dart';
 import 'widgets/edit_section_dialog.dart';
 import 'widgets/pill_view.dart';
 import 'widgets/section_card.dart';
@@ -123,38 +124,27 @@ class _SongConstructorState extends State<SongConstructor> {
   }
 
   void _deleteSection(Section section) {
-    showDialog<void>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Delete Section'),
-        content: Text('Delete "${section.name}"?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: const Text('Cancel'),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              setState(() {
-                // Remove by index using ID comparison
-                final index = _sections.indexWhere((s) => s.id == section.id);
-                if (index != -1) {
-                  _sections = _sections
-                      .where((s) => s.id != section.id)
-                      .toList();
-                }
-              });
-              _notifyChange();
-              Navigator.pop(dialogContext);
-            },
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
-              foregroundColor: Theme.of(context).colorScheme.onError,
-            ),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
+    // ponytail: single-level undo via snackbar; editor undo stack only if beta asks
+    final index = _sections.indexWhere((s) => s.id == section.id);
+    if (index == -1) return;
+
+    final deletedSection = _sections[index];
+    setState(() {
+      _sections = _sections.where((s) => s.id != section.id).toList();
+    });
+    _notifyChange();
+
+    // Show snackbar with undo action
+    showAppSnackBar(
+      context,
+      'Section "${deletedSection.name}" deleted',
+      actionLabel: 'Undo',
+      onAction: () {
+        setState(() {
+          _sections.insert(index, deletedSection);
+        });
+        _notifyChange();
+      },
     );
   }
 
@@ -351,13 +341,31 @@ class _SongConstructorState extends State<SongConstructor> {
                       ),
                       confirmDismiss: (direction) async {
                         if (direction == DismissDirection.endToStart) {
-                          // Swipe left - delete directly (no dialog for swipe)
-                          setState(() {
-                            _sections = _sections
-                                .where((s) => s.id != section.id)
-                                .toList();
-                          });
-                          _notifyChange();
+                          // Swipe left - delete with undo snackbar
+                          final sectionIndex = _sections.indexWhere((s) => s.id == section.id);
+                          if (sectionIndex != -1) {
+                            final deletedSection = _sections[sectionIndex];
+                            setState(() {
+                              _sections = _sections
+                                  .where((s) => s.id != section.id)
+                                  .toList();
+                            });
+                            _notifyChange();
+
+                            if (mounted) {
+                              showAppSnackBar(
+                                context,
+                                'Section "${deletedSection.name}" deleted',
+                                actionLabel: 'Undo',
+                                onAction: () {
+                                  setState(() {
+                                    _sections.insert(sectionIndex, deletedSection);
+                                  });
+                                  _notifyChange();
+                                },
+                              );
+                            }
+                          }
                           return true; // Dismiss the item
                         } else if (direction == DismissDirection.startToEnd) {
                           // Swipe right - edit

--- a/lib/screens/songs/song_editor_screen.dart
+++ b/lib/screens/songs/song_editor_screen.dart
@@ -4,6 +4,7 @@ import 'package:uuid/uuid.dart';
 import '../../models/section.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/chordpro.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/custom_app_bar.dart';
 import 'chordpro_sync_controller.dart';
 import 'components/import_lyrics_dialog.dart';
@@ -197,32 +198,23 @@ class _SongEditorScreenState extends State<SongEditorScreen> {
         _close();
       },
       child: Scaffold(
-        // Standard AppBar + classic 3-dot menu, consistent with the rest of
-        // the app (#79 UX sweep).
+        // Pushed imperatively (Navigator.push), so it lives outside go_router
+        // and can't use the shell's bottom bar — back + menu stay in the top
+        // bar here (menu opens the app menu sheet).
         appBar: CustomAppBar.build(
           context,
           title: (m.title?.isNotEmpty ?? false) ? m.title! : 'Song editor',
           onBack: _close,
           menuItems: [
-            PopupMenuItem<void>(
+            AppMenuItem(
+              icon: Icons.add,
+              label: 'Add section',
               onTap: _addSection,
-              child: const Row(
-                children: [
-                  Icon(Icons.add, size: 20),
-                  SizedBox(width: MonoPulseSpacing.sm),
-                  Text('Add section'),
-                ],
-              ),
             ),
-            PopupMenuItem<void>(
+            AppMenuItem(
+              icon: Icons.playlist_add,
+              label: 'Import lyrics & chords',
               onTap: _import,
-              child: const Row(
-                children: [
-                  Icon(Icons.playlist_add, size: 20),
-                  SizedBox(width: MonoPulseSpacing.sm),
-                  Text('Import lyrics & chords'),
-                ],
-              ),
             ),
           ],
         ),

--- a/lib/screens/songs/songs_list_screen.dart
+++ b/lib/screens/songs/songs_list_screen.dart
@@ -17,6 +17,7 @@ import '../../theme/mono_pulse_theme.dart';
 import '../../utils/key_utils.dart';
 import '../../utils/snackbar.dart';
 import '../../widgets/app_filter_chip.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/confirmation_dialog.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_banner.dart' show ErrorBanner, ErrorBannerStyle;
@@ -304,12 +305,8 @@ class _SongsListScreenState extends ConsumerState<SongsListScreen>
     );
   }
 
-  void _runAfterPopupClose(Future<void> Function() action) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      unawaited(action());
-    });
-  }
+  // (The app menu sheet already closes itself and defers each action to the
+  // next frame, so the old _runAfterPopupClose wrapper is gone.)
 
   /// Filter and sort songs based on search query, key, BPM, tag, and sort option.
   List<Song> _filterAndSortSongs(List<Song> songs) {
@@ -610,27 +607,24 @@ class _SongsListScreenState extends ConsumerState<SongsListScreen>
       title: 'Songs',
       showBackButton: false, // Hide back button for main tabs
       menuItems: [
-        PopupMenuItem<void>(
-          enabled: canExport,
+        AppMenuItem(
+          icon: Icons.control_point_duplicate_outlined,
+          label: 'Find duplicates',
           onTap: canExport
-              ? () => _runAfterPopupClose(
-                  () async => context.pushNamed('song-duplicates'),
-                )
+              ? () async => context.pushNamed('song-duplicates')
               : null,
-          child: const Text('Find duplicates'),
         ),
-        PopupMenuItem<void>(
-          onTap: () => _runAfterPopupClose(_handleImport),
-          child: const Text('Import from CSV'),
+        AppMenuItem(
+          icon: Icons.file_upload_outlined,
+          label: 'Import from CSV',
+          onTap: _handleImport,
         ),
-        PopupMenuItem<void>(
-          enabled: canExport,
+        AppMenuItem(
+          icon: Icons.file_download_outlined,
+          label: 'Export to CSV',
           onTap: canExport
-              ? () => _runAfterPopupClose(
-                  () => _handleExport(List<Song>.from(exportSongs)),
-                )
+              ? () => _handleExport(List<Song>.from(exportSongs))
               : null,
-          child: const Text('Export to CSV'),
         ),
       ],
       floatingActionButton: canEdit

--- a/lib/screens/tuner_screen.dart
+++ b/lib/screens/tuner_screen.dart
@@ -8,6 +8,7 @@ import '../providers/tuner_provider.dart';
 import '../services/analytics_service.dart';
 import '../theme/mono_pulse_theme.dart';
 import '../utils/snackbar.dart';
+import '../widgets/app_menu_sheet.dart';
 import '../widgets/tools/tool_mode_switcher.dart';
 import '../widgets/tools/tool_scaffold.dart';
 import '../widgets/tuner/central_dial.dart';
@@ -111,113 +112,43 @@ class _TunerScreenState extends ConsumerState<TunerScreen>
     );
   }
 
-  List<PopupMenuEntry<dynamic>> _buildMenuItems(TunerState state) {
+  List<AppMenuItem> _buildMenuItems(TunerState state) {
     return [
-      PopupMenuItem<dynamic>(
+      AppMenuItem(
+        icon: Icons.tune,
+        label: 'Tuner Settings',
         onTap: _showSettings,
-        child: Row(
-          children: [
-            const Icon(
-              Icons.tune,
-              color: MonoPulseColors.textSecondary,
-              size: 20,
-            ),
-            const SizedBox(width: MonoPulseSpacing.md),
-            Text(
-              'Tuner Settings',
-              style: MonoPulseTypography.bodyMedium.copyWith(
-                color: MonoPulseColors.textHighEmphasis,
-              ),
-            ),
-          ],
-        ),
       ),
-      PopupMenuItem<dynamic>(
+      AppMenuItem(
+        icon: Icons.piano_outlined,
+        label: 'Instruments & Tunings',
         onTap: _showInstrumentPicker,
-        child: Row(
-          children: [
-            const Icon(
-              Icons.piano_outlined,
-              color: MonoPulseColors.textSecondary,
-              size: 20,
-            ),
-            const SizedBox(width: MonoPulseSpacing.md),
-            Text(
-              'Instruments & Tunings',
-              style: MonoPulseTypography.bodyMedium.copyWith(
-                color: MonoPulseColors.textHighEmphasis,
-              ),
-            ),
-          ],
-        ),
       ),
-      PopupMenuItem<dynamic>(
+      AppMenuItem(
+        icon: Icons.edit_outlined,
+        label: 'Custom Tuning Editor',
         onTap: _showCustomTuningEditor,
-        child: Row(
-          children: [
-            const Icon(
-              Icons.edit_outlined,
-              color: MonoPulseColors.textSecondary,
-              size: 20,
-            ),
-            const SizedBox(width: MonoPulseSpacing.md),
-            Text(
-              'Custom Tuning Editor',
-              style: MonoPulseTypography.bodyMedium.copyWith(
-                color: MonoPulseColors.textHighEmphasis,
-              ),
-            ),
-          ],
-        ),
       ),
-      PopupMenuItem<dynamic>(
+      // Live toggle: the trailing switch rebuilds in-sheet via Riverpod and
+      // does not close the sheet.
+      AppMenuItem(
+        icon: state.stageModeEnabled
+            ? Icons.fullscreen
+            : Icons.fullscreen_outlined,
+        label: 'Stage Mode',
         onTap: () => ref.read(tunerProvider.notifier).toggleStageModeEnabled(),
-        child: Row(
-          children: [
-            Icon(
-              state.stageModeEnabled
-                  ? Icons.fullscreen
-                  : Icons.fullscreen_outlined,
-              color: MonoPulseColors.textSecondary,
-              size: 20,
-            ),
-            const SizedBox(width: MonoPulseSpacing.md),
-            Text(
-              'Stage Mode',
-              style: MonoPulseTypography.bodyMedium.copyWith(
-                color: MonoPulseColors.textHighEmphasis,
-              ),
-            ),
-            const Spacer(),
-            Container(
-              width: 40,
-              height: 24,
-              decoration: BoxDecoration(
-                color: state.stageModeEnabled
-                    ? MonoPulseColors.accentOrange
-                    : MonoPulseColors.borderDefault,
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Stack(
-                children: [
-                  AnimatedAlign(
-                    duration: MonoPulseAnimation.durationMedium,
-                    curve: MonoPulseAnimation.curveCustom,
-                    alignment: state.stageModeEnabled
-                        ? Alignment.centerRight
-                        : Alignment.centerLeft,
-                    child: const Padding(
-                      padding: EdgeInsets.all(3),
-                      child: ColoredBox(
-                        color: MonoPulseColors.white,
-                        child: SizedBox(width: 18, height: 18),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
+        trailing: Consumer(
+          builder: (context, ref, _) {
+            final enabled = ref.watch(
+              tunerProvider.select((s) => s.stageModeEnabled),
+            );
+            return Switch(
+              value: enabled,
+              activeThumbColor: MonoPulseColors.accentOrange,
+              onChanged: (_) =>
+                  ref.read(tunerProvider.notifier).toggleStageModeEnabled(),
+            );
+          },
         ),
       ),
     ];

--- a/lib/utils/snackbar.dart
+++ b/lib/utils/snackbar.dart
@@ -4,14 +4,18 @@ import '../theme/mono_pulse_theme.dart';
 
 /// Shows a MonoPulse-styled snackbar with [message].
 ///
-/// Pass [error]: true for error styling. Replaces the ~scores of inline
+/// Pass [error]: true for error styling. Pass [actionLabel] and [onAction] to
+/// render a snackbar action (e.g., for single-level undo). When an action is
+/// provided, the snackbar duration is ~5s; otherwise it uses the default.
+/// Replaces the ~scores of inline
 /// `ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(...)))`
-/// call sites. For snackbars that need an action, custom duration, or bespoke
-/// content, build the SnackBar inline instead.
+/// call sites.
 void showAppSnackBar(
   BuildContext context,
   String message, {
   bool error = false,
+  String? actionLabel,
+  VoidCallback? onAction,
 }) {
   ScaffoldMessenger.of(context)
     ..hideCurrentSnackBar()
@@ -19,6 +23,15 @@ void showAppSnackBar(
       SnackBar(
         content: Text(message),
         backgroundColor: error ? MonoPulseColors.error : null,
+        duration: actionLabel != null
+            ? const Duration(seconds: 5)
+            : const Duration(seconds: 4),
+        action: actionLabel != null && onAction != null
+            ? SnackBarAction(
+                label: actionLabel,
+                onPressed: onAction,
+              )
+            : null,
       ),
     );
 }

--- a/lib/widgets/app_menu_sheet.dart
+++ b/lib/widgets/app_menu_sheet.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../providers/auth/auth_provider.dart';
+import '../theme/mono_pulse_theme.dart';
+import 'user_avatar.dart';
+
+/// One row in an [showAppMenuSheet] bottom sheet.
+///
+/// Rows with [trailing] (e.g. a live `Switch`) do NOT auto-close the sheet on
+/// tap — the trailing widget itself owns the interaction (its own
+/// `onChanged`), so the sheet can stay open while the user flips a few
+/// settings in a row (Metronome's Haptics, Tuner's Stage Mode). Rows without
+/// [trailing] close the sheet first, then run [onTap] on the next frame (this
+/// mirrors the old `_runAfterMenuCloses` pattern screens used with
+/// `PopupMenuItem`, so a dialog/navigation triggered by [onTap] doesn't race
+/// the sheet's own closing animation).
+class AppMenuItem {
+  const AppMenuItem({
+    required this.icon,
+    required this.label,
+    this.onTap,
+    this.destructive = false,
+    this.trailing,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback? onTap;
+  final bool destructive;
+  final Widget? trailing;
+}
+
+/// The app-wide contextual action sheet, opened from the bottom bar's Menu
+/// slot (root mode: a tab; pushed mode: the `⋮` button). Styled after
+/// `showSupportSheet` — dark theme, rounded top corners, `SafeArea`.
+///
+/// A header row with [title] is always shown. When [showProfileRow] is true
+/// (root mode only — pushed-mode sheets don't offer it, the bottom bar
+/// already shows the Back affordance), a divider + a Profile row is appended;
+/// tapping it closes the sheet and navigates to the Profile branch.
+Future<void> showAppMenuSheet(
+  BuildContext context, {
+  required String title,
+  required List<AppMenuItem> items,
+  bool showProfileRow = false,
+  WidgetRef? ref,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: MonoPulseColors.blackSurface,
+    isScrollControlled: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(MonoPulseRadius.xlarge),
+      ),
+    ),
+    builder: (sheetContext) {
+      // StatefulBuilder gives room for future in-sheet local-state toggles.
+      // The two current live-toggle use cases (Metronome Haptics, Tuner
+      // Stage Mode) are Riverpod-backed, so their `trailing` widgets are
+      // small ConsumerWidgets that rebuild themselves via `ref.watch` —
+      // no `setSheetState` call is required for those, but it's here so a
+      // future non-Riverpod toggle has a safe, local way to rebuild.
+      return StatefulBuilder(
+        builder: (sheetContext, setSheetState) {
+          return SafeArea(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    MonoPulseSpacing.lg,
+                    MonoPulseSpacing.lg,
+                    MonoPulseSpacing.lg,
+                    MonoPulseSpacing.sm,
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: MonoPulseTypography.titleLarge.copyWith(
+                            color: MonoPulseColors.textHighEmphasis,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(height: 1, color: MonoPulseColors.borderSubtle),
+                Flexible(
+                  child: ListView(
+                    shrinkWrap: true,
+                    padding: EdgeInsets.zero,
+                    children: [
+                      for (final item in items)
+                        _AppMenuRow(item: item, sheetContext: sheetContext),
+                      if (showProfileRow) ...[
+                        const Divider(
+                          height: 1,
+                          color: MonoPulseColors.borderSubtle,
+                        ),
+                        _ProfileRow(ref: ref, sheetContext: sheetContext),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+
+class _AppMenuRow extends StatelessWidget {
+  const _AppMenuRow({required this.item, required this.sheetContext});
+
+  final AppMenuItem item;
+  final BuildContext sheetContext;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasTrailing = item.trailing != null;
+    final enabled = hasTrailing || item.onTap != null;
+    final color = item.destructive
+        ? MonoPulseColors.error
+        : enabled
+        ? MonoPulseColors.textHighEmphasis
+        : MonoPulseColors.textTertiary;
+
+    return ListTile(
+      enabled: enabled,
+      leading: Icon(
+        item.icon,
+        size: 20,
+        color: item.destructive ? MonoPulseColors.error : null,
+      ),
+      title: Text(
+        item.label,
+        style: MonoPulseTypography.bodyMedium.copyWith(color: color),
+      ),
+      trailing: item.trailing,
+      onTap: item.onTap == null
+          ? null
+          : hasTrailing
+          // Trailing rows (live toggles) stay open: run the action in place
+          // so the user can flip several settings without reopening.
+          ? item.onTap
+          : () {
+              Navigator.of(sheetContext).pop();
+              final onTap = item.onTap!;
+              WidgetsBinding.instance.addPostFrameCallback((_) => onTap());
+            },
+    );
+  }
+}
+
+class _ProfileRow extends StatelessWidget {
+  const _ProfileRow({required this.ref, required this.sheetContext});
+
+  final WidgetRef? ref;
+  final BuildContext sheetContext;
+
+  @override
+  Widget build(BuildContext context) {
+    String? displayName;
+    String? photoURL;
+    // Defensive: appUserProvider may not have resolved yet (or ref may be
+    // null when the sheet was opened outside a ConsumerWidget) — fall back
+    // to a generic "Profile" row rather than throwing.
+    final currentRef = ref;
+    if (currentRef != null) {
+      try {
+        final user = currentRef.read(appUserProvider).value;
+        displayName = user?.displayName;
+        photoURL = user?.photoURL;
+      } on Object {
+        // Provider not available in this context — keep the fallback.
+      }
+    }
+
+    return ListTile(
+      leading: UserAvatar(
+        photoURL: photoURL,
+        displayName: displayName,
+        radius: 16,
+      ),
+      title: Text(
+        displayName?.isNotEmpty ?? false ? displayName! : 'Profile',
+        style: MonoPulseTypography.bodyMedium.copyWith(
+          color: MonoPulseColors.textHighEmphasis,
+        ),
+      ),
+      onTap: () {
+        // Resolve the router before popping — `context` (and `sheetContext`)
+        // may be deactivated by the time the post-frame callback runs, but a
+        // `GoRouter` instance is safe to hold onto and call later.
+        final router = GoRouter.of(context);
+        Navigator.of(sheetContext).pop();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          router.go('/main/profile');
+        });
+      },
+    );
+  }
+}

--- a/lib/widgets/bottom_nav_or_action_bar.dart
+++ b/lib/widgets/bottom_nav_or_action_bar.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+
+import '../theme/mono_pulse_theme.dart';
+
+/// One navigation destination, shared by the portrait bottom bar and the
+/// landscape rail (Mono Pulse: "nav moves to a side rail").
+typedef AppNavItem = ({IconData icon, IconData selectedIcon, String label});
+
+/// The bottom bar / rail, in one of two mutually exclusive modes:
+///
+/// - [AppBottomBar.tabs]: the 4 branch tabs + a Menu slot (opens a bottom
+///   sheet, never navigates). Shown while on one of the 5 branch roots.
+/// - [AppBottomBar.actions]: `[← Back] [title | primaryAction] [⋮ Menu]`.
+///   Shown for any pushed route — both branch children (e.g. edit-song) and
+///   root-pushed tools (Metronome/Tuner/Join Band).
+///
+/// Both modes share the same height/padding/border chrome so switching
+/// between them doesn't jump the layout.
+class AppBottomBar extends StatelessWidget {
+  const AppBottomBar.tabs({
+    required this.tabs,
+    required this.selectedIndex,
+    required this.onTabTap,
+    this.onMenuTap,
+    this.menuSelected = false,
+    this.menuHasBadge = false,
+    super.key,
+  }) : _isTabs = true,
+       onBack = null,
+       title = null,
+       primaryAction = null,
+       onMenu = null;
+
+  const AppBottomBar.actions({
+    required this.onBack,
+    this.title,
+    this.primaryAction,
+    this.onMenu,
+    super.key,
+  }) : _isTabs = false,
+       tabs = const [],
+       selectedIndex = 0,
+       onTabTap = null,
+       onMenuTap = null,
+       menuSelected = false,
+       menuHasBadge = false;
+
+  final bool _isTabs;
+
+  // .tabs mode
+  final List<AppNavItem> tabs;
+  final int selectedIndex;
+  final ValueChanged<int>? onTabTap;
+  final VoidCallback? onMenuTap;
+  final bool menuSelected;
+  final bool menuHasBadge;
+
+  // .actions mode
+  final VoidCallback? onBack;
+  final String? title;
+  final Widget? primaryAction;
+  final VoidCallback? onMenu;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(
+        color: MonoPulseColors.black,
+        border: Border(top: BorderSide(color: MonoPulseColors.borderSubtle)),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: MonoPulseSpacing.sm,
+            vertical: MonoPulseSpacing.sm,
+          ),
+          child: _isTabs ? _buildTabs() : _buildActions(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTabs() {
+    return Row(
+      children: [
+        for (var i = 0; i < tabs.length; i++)
+          Expanded(
+            child: NavTab(
+              item: tabs[i],
+              selected: i == selectedIndex,
+              onTap: () => onTabTap?.call(i),
+            ),
+          ),
+        Expanded(
+          child: NavTab(
+            item: const (
+              icon: Icons.more_horiz,
+              selectedIcon: Icons.more_horiz,
+              label: 'Menu',
+            ),
+            selected: menuSelected,
+            showBadge: menuHasBadge,
+            onTap: onMenuTap ?? () {},
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildActions() {
+    return Row(
+      children: [
+        Expanded(
+          child: NavTab(
+            item: const (
+              icon: Icons.arrow_back,
+              selectedIcon: Icons.arrow_back,
+              label: 'Back',
+            ),
+            selected: false,
+            onTap: onBack ?? () {},
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          // heightFactor keeps the Center from expanding vertically: the
+          // Scaffold gives bottomNavigationBar loose height constraints, and
+          // an unbounded Center would balloon the bar to fill the screen.
+          child: Center(
+            heightFactor: 1,
+            child: primaryAction != null
+                // Scale an oversized primary action (e.g. a full button) down
+                // to the slot instead of overflowing on narrow screens.
+                ? FittedBox(fit: BoxFit.scaleDown, child: primaryAction)
+                :
+                (title == null || title!.isEmpty
+                    ? const SizedBox.shrink()
+                    : Semantics(
+                        label: title,
+                        child: Text(
+                          title!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.center,
+                          style: MonoPulseTypography.labelLarge.copyWith(
+                            color: MonoPulseColors.textPrimary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      )),
+          ),
+        ),
+        Expanded(
+          child: onMenu == null
+              ? const SizedBox.shrink()
+              : NavTab(
+                  item: const (
+                    icon: Icons.more_horiz,
+                    selectedIcon: Icons.more_horiz,
+                    label: 'Menu',
+                  ),
+                  selected: false,
+                  onTap: onMenu!,
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A single nav/action tab (Mono Pulse): icon on top, label below. When
+/// selected the icon + label turn orange and the label gets a rounded pill
+/// background. Shared by [AppBottomBar]'s tabs mode, its actions mode
+/// (Back/Menu buttons), and the landscape rail. Keeps a >=48px tap target.
+class NavTab extends StatelessWidget {
+  const NavTab({
+    required this.item,
+    required this.selected,
+    required this.onTap,
+    this.showBadge = false,
+    super.key,
+  });
+
+  final AppNavItem item;
+  final bool selected;
+  final VoidCallback onTap;
+
+  /// Small dot shown near the icon (Menu slot: current screen published
+  /// contextual actions).
+  final bool showBadge;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = selected
+        ? MonoPulseColors.accentOrange
+        : MonoPulseColors.textTertiary;
+
+    final label = Text(
+      item.label,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: MonoPulseTypography.labelSmall.copyWith(
+        color: color,
+        fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+      ),
+    );
+
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: item.label,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(MonoPulseRadius.medium),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 48),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  Icon(selected ? item.selectedIcon : item.icon, color: color, size: 22),
+                  if (showBadge)
+                    Positioned(
+                      right: -2,
+                      top: -2,
+                      child: Container(
+                        width: 8,
+                        height: 8,
+                        decoration: const BoxDecoration(
+                          color: MonoPulseColors.accentOrange,
+                          shape: BoxShape.circle,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: MonoPulseSpacing.xs),
+              // Pill behind the label only when selected (per the doc's tab bar).
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: selected
+                      ? MonoPulseColors.accentOrange15
+                      : MonoPulseColors.transparent,
+                  borderRadius: BorderRadius.circular(MonoPulseRadius.huge),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: MonoPulseSpacing.sm,
+                    vertical: MonoPulseSpacing.xxs,
+                  ),
+                  child: label,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/custom_app_bar.dart
+++ b/lib/widgets/custom_app_bar.dart
@@ -1,58 +1,57 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:go_router/go_router.dart';
 import '../theme/mono_pulse_theme.dart';
+import 'app_menu_sheet.dart';
 
-/// Custom AppBar with consistent back button and menu across all screens.
+/// Slim top app bar: centered title only (bottom-first navigation redesign).
 ///
-/// Features:
-/// - Circular back button with border (consistent with Mono Pulse design)
-/// - Three dots menu button for screen-specific actions
-/// - Haptic feedback on tap
-/// - 48px minimum touch zones
+/// Back and the `⋮` contextual menu moved to the bottom bar (`AppBottomBar`):
+/// pushed screens get `[← Back] [title] [⋮ Menu]` from the shell (branch
+/// children) or from their own scaffold (root-pushed tools), and branch roots
+/// get the tab bar with the Menu slot. The top bar's only job now is naming
+/// the screen.
 ///
-/// Usage:
-/// ```dart
-/// appBar: CustomAppBar.build(
-///   context,
-///   title: 'Songs',
-///   menuItems: [
-///     PopupMenuItem(child: Text('Import'), onTap: _handleImport),
-///     PopupMenuItem(child: Text('Export'), onTap: _handleExport),
-///   ],
-/// ),
-/// ```
+/// Exception: screens pushed imperatively via `Navigator.push` (Performance
+/// Sheet, Song Editor, AI access) live outside go_router, so the shell's
+/// bottom bar can't serve them — they pass `onBack` (and optionally
+/// `menuItems`) to keep a working back/menu in the top bar until they are
+/// migrated to routes.
 class CustomAppBar {
   CustomAppBar._();
 
-  /// Builds a custom AppBar with back button and menu.
+  /// Builds the slim app bar.
   ///
-  /// [context] - Build context for navigation
-  /// [title] - AppBar title text
-  /// [menuItems] - Screen-specific menu items
-  /// [actions] - Extra action widgets shown before the menu button
-  /// [onBack] - Custom back action (optional, defaults to Navigator.pop)
-  /// [isTool] - Whether this is a tool screen (uses titleLarge typography)
+  /// [title] - centered title text
+  /// [actions] - extra action widgets (right side)
+  /// [onBack] - ONLY for imperatively-pushed screens (see class doc); renders
+  ///   the circular back button. Router-routed screens must leave this null —
+  ///   the bottom bar owns Back.
+  /// [menuItems] - ONLY for imperatively-pushed screens; renders a `⋮` that
+  ///   opens the app menu sheet.
+  /// [isTool] - tool screens use titleLarge typography
   static PreferredSizeWidget build(
     BuildContext context, {
     required String title,
     bool isTool = false,
-    List<PopupMenuEntry<dynamic>>? menuItems,
     List<Widget>? actions,
     VoidCallback? onBack,
+    List<AppMenuItem>? menuItems,
   }) {
     return AppBar(
       backgroundColor: MonoPulseColors.black,
       foregroundColor: MonoPulseColors.textPrimary,
       elevation: 0,
       systemOverlayStyle: SystemUiOverlayStyle.light,
-      leading: _backButton(context, onBack),
+      automaticallyImplyLeading: false,
+      leading: onBack != null ? _backButton(onBack) : null,
       title: Text(
         title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
         style:
             (isTool
                     ? MonoPulseTypography.titleLarge
-                    : MonoPulseTypography.headlineLarge)
+                    : MonoPulseTypography.headlineSmall)
                 .copyWith(
                   color: MonoPulseColors.textHighEmphasis,
                   fontWeight: FontWeight.w700,
@@ -61,72 +60,43 @@ class CustomAppBar {
       centerTitle: true,
       actions: [
         ...?actions,
-        if (menuItems?.isNotEmpty ?? false) _menuButton(menuItems!),
+        if (menuItems?.isNotEmpty ?? false)
+          _menuButton(context, title, menuItems!),
         const SizedBox(width: MonoPulseSpacing.md),
       ],
     );
   }
 
-  /// Builds a custom AppBar with only a back button.
-  static PreferredSizeWidget buildSimple(
-    BuildContext context, {
-    required String title,
-    VoidCallback? onBack,
-  }) => build(context, title: title, onBack: onBack);
-
-  /// Builds a custom AppBar without back button (for main shell tabs).
-  ///
-  /// Use this for screens that are part of the bottom navigation
-  /// and should not have a back button.
-  static PreferredSizeWidget buildNoBack(
-    BuildContext context, {
-    required String title,
-    List<PopupMenuEntry<dynamic>>? menuItems,
-  }) {
-    return AppBar(
-      backgroundColor: MonoPulseColors.black,
-      foregroundColor: MonoPulseColors.textPrimary,
-      elevation: 0,
-      systemOverlayStyle: SystemUiOverlayStyle.light,
-      leading: const SizedBox(width: MonoPulseSpacing.massive), // Empty space for alignment (48px)
-      title: Text(
-        title,
-        style: MonoPulseTypography.headlineLarge.copyWith(
-          color: MonoPulseColors.textHighEmphasis,
-          fontWeight: FontWeight.w700,
-        ),
-      ),
-      centerTitle: true,
-      actions: [
-        if (menuItems?.isNotEmpty ?? false) _menuButton(menuItems!),
-        const SizedBox(width: MonoPulseSpacing.md),
-      ],
-    );
-  }
-
-  static Widget _menuButton(List<PopupMenuEntry<dynamic>> menuItems) {
-    return GestureDetector(
-      onTap: HapticFeedback.lightImpact,
-      // minTapTarget touch zone
-      child: SizedBox(
-        width: MonoPulseSpacing.massive, // 48px
-        height: MonoPulseSpacing.massive,
-        child: Center(
-          child: Container(
-            width: 40,
-            height: 40,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              border: Border.all(color: MonoPulseColors.borderSubtle),
-            ),
-            child: PopupMenuButton<void>(
-              padding: EdgeInsets.zero,
-              icon: const Icon(
+  static Widget _menuButton(
+    BuildContext context,
+    String title,
+    List<AppMenuItem> menuItems,
+  ) {
+    return Semantics(
+      button: true,
+      label: 'Menu',
+      child: GestureDetector(
+        onTap: () {
+          HapticFeedback.lightImpact();
+          showAppMenuSheet(context, title: title, items: menuItems);
+        },
+        // minTapTarget touch zone
+        child: SizedBox(
+          width: MonoPulseSpacing.massive, // 48px
+          height: MonoPulseSpacing.massive,
+          child: Center(
+            child: Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: MonoPulseColors.borderSubtle),
+              ),
+              child: const Icon(
                 Icons.more_horiz,
                 color: MonoPulseColors.textSecondary,
                 size: MonoPulseIcons.sizeLarge,
               ),
-              itemBuilder: (_) => menuItems,
             ),
           ),
         ),
@@ -134,28 +104,11 @@ class CustomAppBar {
     );
   }
 
-  static Widget _backButton(BuildContext context, VoidCallback? onBack) {
+  static Widget _backButton(VoidCallback onBack) {
     return GestureDetector(
       onTap: () {
         HapticFeedback.lightImpact();
-        if (onBack != null) {
-          onBack();
-        } else if (context.canPop()) {
-          // Screen was push()ed via go_router — pop it. This covers
-          // Metronome/Tuner/Join Band too: they're pushed on the root
-          // navigator on top of the shell, so there's a shell screen
-          // underneath to return to.
-          context.pop();
-        } else if (Navigator.of(context).canPop()) {
-          // Screen was pushed imperatively (e.g. AI access via Navigator.push);
-          // go_router's pop can't see it, so pop the Navigator directly.
-          Navigator.of(context).pop();
-        } else {
-          // Reached via go()/goNamed() which replaced the stack (e.g. a
-          // deep-link cold start landing directly on Join Band) — nothing to
-          // pop, so fall back home instead of a dead button.
-          context.go('/main/home');
-        }
+        onBack();
       },
       // minTapTarget touch zone
       child: SizedBox(

--- a/lib/widgets/menu_items_scope.dart
+++ b/lib/widgets/menu_items_scope.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'app_menu_sheet.dart';
+
+/// Ambient "what menu does the current screen offer" data, carried down the
+/// tree as a plain [InheritedWidget]. Cheap local lookup for a descendant
+/// that wants its nearest ancestor screen's menu without prop-drilling
+/// title/items through every constructor.
+///
+/// This does NOT solve the shell's problem of reading the *currently visible*
+/// screen's menu — the shell is an ancestor of the branch content (and
+/// root-pushed tool routes live on a different `Navigator` entirely), so it
+/// can never be a descendant of the screen it wants to read. For that,
+/// [MenuScopeRegistry] below (a plain, non-Riverpod notifier) is the
+/// cross-navigator channel; screens publish into it via [MenuScopePublisher].
+class MenuItemsScope extends InheritedWidget {
+  const MenuItemsScope({
+    required this.title,
+    required this.items,
+    required super.child,
+    super.key,
+  });
+
+  final String title;
+  final List<AppMenuItem> items;
+
+  static MenuItemsScope? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<MenuItemsScope>();
+  }
+
+  static MenuItemsScope of(BuildContext context) {
+    final scope = maybeOf(context);
+    assert(scope != null, 'No MenuItemsScope found in context');
+    return scope!;
+  }
+
+  @override
+  bool updateShouldNotify(MenuItemsScope oldWidget) {
+    return title != oldWidget.title || items != oldWidget.items;
+  }
+}
+
+/// The Back/Title/Menu bar content the shell should show for one screen.
+class MenuScopeData {
+  const MenuScopeData({
+    required this.title,
+    this.items = const [],
+    this.primaryAction,
+  });
+
+  final String title;
+  final List<AppMenuItem> items;
+
+  /// Replaces the title slot in the pushed-mode bottom bar (e.g.
+  /// `SetlistViewScreen`'s "Open in Metronome" button). [title] still names
+  /// the menu sheet when [items] is non-empty.
+  final Widget? primaryAction;
+}
+
+/// Cross-navigator registry the shell reads to render its pushed-mode bottom
+/// bar (Back / title / Menu) and its root-mode Menu dot badge, without
+/// needing an `InheritedWidget` descendant relationship it can't have.
+///
+/// Entries are keyed by go_router location and never removed on dispose —
+/// only overwritten by a fresh registration for that same location. This
+/// sidesteps a dispose-ordering race: branch roots are kept alive forever by
+/// `StatefulShellRoute.indexedStack` and only run `initState` once, while
+/// pushed children mount/unmount on every push/pop. If a pushed child's
+/// `dispose()` blindly cleared a single shared "current" slot, popping back
+/// to a root screen would leave the shell reading a wiped value instead of
+/// the still-mounted root screen's entry. Keying by location means each
+/// screen's last-known data is always exactly where the shell looks for it,
+/// whether that screen ever runs its lifecycle callbacks again or not.
+class MenuScopeRegistry {
+  MenuScopeRegistry._();
+
+  static final Map<String, MenuScopeData> _entries = <String, MenuScopeData>{};
+
+  /// Bumped on every publish so listeners (the shell) can rebuild without
+  /// needing to know which keys changed.
+  static final ValueNotifier<int> revision = ValueNotifier<int>(0);
+
+  static MenuScopeData? forLocation(String location) => _entries[location];
+
+  static void publish(String location, MenuScopeData data) {
+    _entries[location] = data;
+    revision.value++;
+  }
+
+  /// Live publishers in mount order, keyed by State identity — unlike the
+  /// location map these ARE removed on dispose, which is safe because
+  /// removal is by token, immune to indexedStack dispose-ordering.
+  static final List<_StackEntry> _stack = <_StackEntry>[];
+
+  static void attach(Object token, String location, MenuScopeData data) {
+    final i = _stack.indexWhere((e) => identical(e.token, token));
+    if (i >= 0) {
+      _stack[i] = (token: token, location: location, data: data);
+    } else {
+      _stack.add((token: token, location: location, data: data));
+    }
+    revision.value++;
+  }
+
+  static void detach(Object token) {
+    _stack.removeWhere((e) => identical(e.token, token));
+    revision.value++;
+  }
+
+  /// The deepest live publisher for a screen pushed ABOVE [branchRoot]
+  /// (location strictly below the root). Null when the pushed screen didn't
+  /// publish a menu — the shell then hides the bar's ⋮ instead of showing
+  /// the root screen's (wrong) menu.
+  static MenuScopeData? pushedEntryFor(String branchRoot) {
+    for (final e in _stack.reversed) {
+      if (e.location != branchRoot && e.location.startsWith(branchRoot)) {
+        return e.data;
+      }
+    }
+    return null;
+  }
+
+  /// Test hook: wipe all entries between pumps.
+  @visibleForTesting
+  static void reset() {
+    _entries.clear();
+    _stack.clear();
+    revision.value++;
+  }
+}
+
+typedef _StackEntry = ({Object token, String location, MenuScopeData data});
+
+/// Publishes [data] into [MenuScopeRegistry] under this screen's go_router
+/// location for as long as this widget is in the tree, and exposes it locally
+/// as a [MenuItemsScope].
+///
+/// The location key is captured ONCE, on first `didChangeDependencies`
+/// (`GoRouterState.of(context).uri`) — never re-read on rebuild. A kept-alive
+/// branch-root screen that rebuilds while a child route is on top would
+/// otherwise see the CHILD's uri in its own `GoRouterState` and clobber the
+/// child's registry entry with the root's data.
+///
+/// Writes are deferred to a post-frame callback (never done synchronously
+/// during build/lifecycle) — mutating shared state that an ancestor (the
+/// shell) listens to, mid-build, is the exact "setState() called during
+/// build" screen-blanking regression class this app has hit before with
+/// Riverpod provider writes; a plain `ValueNotifier` isn't immune to the same
+/// assertion if a listener reacts synchronously.
+///
+/// Screens without a GoRouter ancestor (imperative `Navigator.push` overlays,
+/// bare widget tests) simply don't publish; the local [MenuItemsScope] still
+/// works.
+class MenuScopePublisher extends StatefulWidget {
+  const MenuScopePublisher({
+    required this.data,
+    required this.child,
+    super.key,
+  });
+
+  final MenuScopeData data;
+  final Widget child;
+
+  @override
+  State<MenuScopePublisher> createState() => _MenuScopePublisherState();
+}
+
+class _MenuScopePublisherState extends State<MenuScopePublisher> {
+  String? _location;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_location == null) {
+      try {
+        _location = GoRouterState.of(context).uri.toString();
+      } catch (_) {
+        // Not under a GoRoute (imperative push, widget test) — no registry
+        // publication; the shell can't see this screen anyway.
+        return;
+      }
+      _publish();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant MenuScopePublisher oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_location != null) _publish();
+  }
+
+  void _publish() {
+    final location = _location;
+    if (location == null) return;
+    final data = widget.data;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      MenuScopeRegistry.publish(location, data);
+      if (mounted) MenuScopeRegistry.attach(this, location, data);
+    });
+  }
+
+  @override
+  void dispose() {
+    final token = this;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      MenuScopeRegistry.detach(token);
+    });
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MenuItemsScope(
+      title: widget.data.title,
+      items: widget.data.items,
+      child: widget.child,
+    );
+  }
+}

--- a/lib/widgets/metronome/song_library_block.dart
+++ b/lib/widgets/metronome/song_library_block.dart
@@ -11,6 +11,8 @@ import '../../theme/mono_pulse_theme.dart';
 import '../../utils/snackbar.dart';
 import '../error_banner.dart' show ErrorBanner, ErrorBannerStyle;
 
+typedef _LoadedSongState = ({Song song, Setlist? setlist, String? sourceBandId, List<Song> loadedSetlistSongs});
+
 class SongLibraryBlock extends ConsumerWidget {
   const SongLibraryBlock({super.key});
 
@@ -184,7 +186,44 @@ class _LoadedSongCard extends ConsumerWidget {
           ),
           IconButton(
             tooltip: 'Clear loaded song',
-            onPressed: onClear,
+            onPressed: () {
+              // Cache the current state for undo
+              final cachedState = (
+                song: song,
+                setlist: setlist,
+                sourceBandId: sourceBandId,
+                loadedSetlistSongs: setlist != null
+                    ? ref.read(metronomeProvider).loadedSetlistSongs
+                    : <Song>[],
+              ) as _LoadedSongState;
+
+              // Clear the loaded content
+              onClear();
+
+              // Show snackbar with undo action
+              showAppSnackBar(
+                context,
+                'Song unloaded',
+                actionLabel: 'Undo',
+                onAction: () {
+                  final notifier = ref.read(metronomeProvider.notifier);
+                  if (cachedState.setlist != null) {
+                    // Reload the setlist
+                    notifier.loadSetlistQueue(
+                      cachedState.setlist!,
+                      availableSongs: cachedState.loadedSetlistSongs,
+                      sourceBandId: cachedState.sourceBandId,
+                    );
+                  } else {
+                    // Reload the single song
+                    notifier.loadSongTempo(
+                      cachedState.song,
+                      sourceBandId: cachedState.sourceBandId,
+                    );
+                  }
+                },
+              );
+            },
             icon: const Icon(
               Icons.close,
               color: MonoPulseColors.textSecondary,

--- a/lib/widgets/standard_screen_scaffold.dart
+++ b/lib/widgets/standard_screen_scaffold.dart
@@ -1,16 +1,21 @@
 import 'package:flutter/material.dart';
 
 import '../theme/mono_pulse_theme.dart';
+import 'app_menu_sheet.dart';
 import 'custom_app_bar.dart';
+import 'menu_items_scope.dart';
 import 'offline_indicator.dart';
 
 /// Standard screen scaffold providing consistent layout across all screens.
 ///
-/// Features:
-/// - CustomAppBar with optional back button and menu
-/// - Offline indicator banner (optional)
-/// - Consistent background color (MonoPulseColors.black)
-/// - SafeArea handling
+/// Bottom-first navigation redesign:
+/// - Top bar is a slim centered title only (no back arrow, no ⋮ menu).
+/// - The screen's [title] and [menuItems] are published into
+///   [MenuScopeRegistry] (via [MenuScopePublisher]) so the shell's bottom bar
+///   can render them: on branch roots the Menu tab opens a sheet with these
+///   items (plus a dot badge when items exist); on pushed branch children the
+///   bar becomes `[← Back] [title] [⋮ Menu]`.
+/// - Offline indicator banner behavior is unchanged.
 ///
 /// Usage:
 /// ```dart
@@ -18,10 +23,9 @@ import 'offline_indicator.dart';
 ///   title: 'Songs',
 ///   body: SingleChildScrollView(child: ...),
 ///   menuItems: [
-///     PopupMenuItem(child: Text('Import'), onTap: _import),
+///     AppMenuItem(icon: Icons.upload, label: 'Import', onTap: _import),
 ///   ],
 ///   floatingActionButton: FloatingActionButton(...),
-///   showBackButton: false, // Hide back button for main tabs
 /// )
 /// ```
 class StandardScreenScaffold extends StatelessWidget {
@@ -35,14 +39,14 @@ class StandardScreenScaffold extends StatelessWidget {
     this.menuItems,
     this.floatingActionButton,
   });
-  /// Screen title displayed in AppBar.
+  /// Screen title displayed in the slim top bar and the bottom bar.
   final String title;
 
   /// Main body content of the screen.
   final Widget body;
 
-  /// Optional menu items for three-dots menu.
-  final List<PopupMenuEntry<dynamic>>? menuItems;
+  /// Contextual actions for the bottom bar's Menu sheet.
+  final List<AppMenuItem>? menuItems;
 
   /// Optional floating action button.
   final Widget? floatingActionButton;
@@ -50,27 +54,25 @@ class StandardScreenScaffold extends StatelessWidget {
   /// Whether to show offline indicator banner.
   final bool showOfflineIndicator;
 
-  /// Whether to show back button in AppBar.
+  /// Legacy knob from the top-bar era; the slim top bar never shows a back
+  /// button (Back lives in the bottom bar). Kept so call sites don't churn.
   final bool showBackButton;
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: MonoPulseColors.black,
-      appBar: showBackButton
-          ? CustomAppBar.build(context, title: title, menuItems: menuItems)
-          : CustomAppBar.buildNoBack(
-              context,
-              title: title,
-              menuItems: menuItems,
-            ),
-      body: Column(
-        children: [
-          if (showOfflineIndicator) const OfflineIndicator.banner(),
-          Expanded(child: body),
-        ],
+    return MenuScopePublisher(
+      data: MenuScopeData(title: title, items: menuItems ?? const []),
+      child: Scaffold(
+        backgroundColor: MonoPulseColors.black,
+        appBar: CustomAppBar.build(context, title: title),
+        body: Column(
+          children: [
+            if (showOfflineIndicator) const OfflineIndicator.banner(),
+            Expanded(child: body),
+          ],
+        ),
+        floatingActionButton: floatingActionButton,
       ),
-      floatingActionButton: floatingActionButton,
     );
   }
 }

--- a/lib/widgets/tools/tool_scaffold.dart
+++ b/lib/widgets/tools/tool_scaffold.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../theme/mono_pulse_theme.dart';
+import '../../widgets/app_menu_sheet.dart';
+import '../../widgets/bottom_nav_or_action_bar.dart';
 import '../../widgets/custom_app_bar.dart';
 import '../../widgets/offline_indicator.dart';
 
@@ -90,19 +93,20 @@ class ToolTouchTarget {
   }
 }
 
-/// Base scaffold for all tool screens.
+/// Base scaffold for all tool screens (Metronome/Tuner/Practice).
 ///
-/// Provides consistent structure:
-/// - AppBar with back button, title, 3-dot menu
-/// - Main tool widget (takes available space)
-/// - Optional bottom transport bar
-/// - No bottom navigation bar (tools are full-screen)
+/// Tools are pushed on the ROOT navigator (outside the shell), so the shell's
+/// bottom bar isn't there — this scaffold renders its own pushed-mode bar:
+/// `[← Back] [title] [⋮ Menu]` ([AppBottomBar.actions]). Back pops with a
+/// `/main/home` fallback (deep-link cold start); Menu opens the app menu
+/// sheet with [menuItems] and is hidden when there are none. The top bar is a
+/// slim centered title only.
 ///
 /// Usage:
 /// ```dart
 /// ToolScreenScaffold(
 ///   title: 'Metronome',
-///   menuItems: [...],
+///   menuItems: [AppMenuItem(...), ...],
 ///   mainWidget: CentralTempoCircle(),
 ///   bottomWidget: BottomTransportBar(),
 /// )
@@ -130,14 +134,15 @@ class ToolScreenScaffold extends StatelessWidget {
   /// Optional bottom widget (e.g., transport bar).
   final Widget? bottomWidget;
 
-  /// Menu items for 3-dot menu.
-  final List<PopupMenuEntry<dynamic>>? menuItems;
+  /// Contextual actions for the bottom bar's Menu sheet.
+  final List<AppMenuItem>? menuItems;
 
   /// Whether to show offline indicator.
   final bool showOfflineIndicator;
 
   @override
   Widget build(BuildContext context) {
+    final items = menuItems ?? const <AppMenuItem>[];
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle.light,
       child: Scaffold(
@@ -145,10 +150,11 @@ class ToolScreenScaffold extends StatelessWidget {
         appBar: CustomAppBar.build(
           context,
           title: title,
-          menuItems: menuItems,
           isTool: true,
         ),
         body: SafeArea(
+          // The bottom bar has its own SafeArea for the home-indicator inset.
+          bottom: false,
           child: Column(
             children: [
               if (showOfflineIndicator) const OfflineIndicator.banner(),
@@ -166,6 +172,24 @@ class ToolScreenScaffold extends StatelessWidget {
               ],
             ],
           ),
+        ),
+        bottomNavigationBar: AppBottomBar.actions(
+          onBack: () {
+            if (context.canPop()) {
+              // Tools are pushed on the root navigator on top of the shell,
+              // so there's a shell screen underneath to return to.
+              context.pop();
+            } else {
+              // Reached via go()/deep link that replaced the stack — nothing
+              // to pop, fall back home instead of a dead button.
+              context.go('/main/home');
+            }
+          },
+          // No bar title: the slim top app-bar title is the location signal
+          // (avoids the double-title the first cut had on tool screens).
+          onMenu: items.isEmpty
+              ? null
+              : () => showAppMenuSheet(context, title: title, items: items),
         ),
       ),
     );

--- a/test/helpers/routed_test_harness.dart
+++ b/test/helpers/routed_test_harness.dart
@@ -5,8 +5,11 @@ import 'package:flowgroove/router/app_router.dart';
 import 'package:flowgroove/screens/auth/register_screen.dart';
 import 'package:flowgroove/screens/bands/my_bands_screen.dart';
 import 'package:flowgroove/screens/login_screen.dart';
+import 'package:flowgroove/screens/main_shell.dart';
 import 'package:flowgroove/screens/setlists/setlists_list_screen.dart';
 import 'package:flowgroove/screens/songs/songs_list_screen.dart';
+import 'package:flowgroove/router/branch_stack_observer.dart';
+import 'package:flowgroove/widgets/menu_items_scope.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -119,89 +122,133 @@ GoRouter createRoutedTestRouter({
             builder: (context, state) => const RegisterScreen(),
           ),
           GoRoute(
-            path: '/main/home',
-            name: 'home',
-            builder: (context, state) => const TestRouteMarker('home'),
-          ),
-          GoRoute(
             path: '/main/join-band',
             name: 'join-band',
             builder: (context, state) => const TestRouteMarker('join-band'),
           ),
-          GoRoute(
-            path: '/main/songs',
-            name: 'songs',
-            builder: (context, state) => const SongsListScreen(),
-            routes: [
-              GoRoute(
-                path: 'add',
-                name: 'add-song',
-                builder: (context, state) => const TestRouteMarker('add-song'),
+          // Mirror production: the 5 main branches live under the real
+          // MainShell, so tests exercise the bottom-first navigation (tab
+          // bar / rail, Menu-in-bottom-bar sheet, pushed-mode Back).
+          StatefulShellRoute.indexedStack(
+            builder: (context, state, navigationShell) =>
+                MainShell(navigationShell: navigationShell),
+            branches: [
+              StatefulShellBranch(
+                observers: [BranchStackObserver(0)],
+                routes: [
+                  GoRoute(
+                    path: '/main/home',
+                    name: 'home',
+                    builder: (context, state) => const TestRouteMarker('home'),
+                  ),
+                ],
               ),
-              GoRoute(
-                path: ':id/edit',
-                name: 'edit-song',
-                builder: (context, state) => const TestRouteMarker('edit-song'),
+              StatefulShellBranch(
+                observers: [BranchStackObserver(1)],
+                routes: [
+                  GoRoute(
+                    path: '/main/songs',
+                    name: 'songs',
+                    builder: (context, state) => const SongsListScreen(),
+                    routes: [
+                      GoRoute(
+                        path: 'add',
+                        name: 'add-song',
+                        builder: (context, state) =>
+                            const TestRouteMarker('add-song'),
+                      ),
+                      GoRoute(
+                        path: ':id/edit',
+                        name: 'edit-song',
+                        builder: (context, state) =>
+                            const TestRouteMarker('edit-song'),
+                      ),
+                    ],
+                  ),
+                ],
               ),
-            ],
-          ),
-          GoRoute(
-            path: '/main/bands',
-            name: 'bands',
-            builder: (context, state) => const MyBandsScreen(),
-            routes: [
-              GoRoute(
-                path: 'create',
-                name: 'create-band',
-                builder: (context, state) =>
-                    const TestRouteMarker('create-band'),
+              StatefulShellBranch(
+                observers: [BranchStackObserver(2)],
+                routes: [
+                  GoRoute(
+                    path: '/main/bands',
+                    name: 'bands',
+                    builder: (context, state) => const MyBandsScreen(),
+                    routes: [
+                      GoRoute(
+                        path: 'create',
+                        name: 'create-band',
+                        builder: (context, state) =>
+                            const TestRouteMarker('create-band'),
+                      ),
+                      GoRoute(
+                        path: ':id',
+                        name: 'the-band',
+                        builder: (context, state) =>
+                            const TestRouteMarker('the-band'),
+                      ),
+                      GoRoute(
+                        path: ':id/edit',
+                        name: 'edit-band',
+                        builder: (context, state) =>
+                            const TestRouteMarker('edit-band'),
+                      ),
+                      GoRoute(
+                        path: ':id/songs',
+                        name: 'band-songs',
+                        builder: (context, state) =>
+                            const TestRouteMarker('band-songs'),
+                      ),
+                      GoRoute(
+                        path: ':id/setlists',
+                        name: 'band-setlists',
+                        builder: (context, state) =>
+                            const TestRouteMarker('band-setlists'),
+                      ),
+                    ],
+                  ),
+                ],
               ),
-              GoRoute(
-                path: ':id',
-                name: 'the-band',
-                builder: (context, state) => const TestRouteMarker('the-band'),
+              StatefulShellBranch(
+                observers: [BranchStackObserver(3)],
+                routes: [
+                  GoRoute(
+                    path: '/main/setlists',
+                    name: 'setlists',
+                    builder: (context, state) => const SetlistsListScreen(),
+                    routes: [
+                      GoRoute(
+                        path: 'create',
+                        name: 'create-setlist',
+                        builder: (context, state) =>
+                            const TestRouteMarker('create-setlist'),
+                      ),
+                      GoRoute(
+                        path: ':id',
+                        name: 'setlist-view',
+                        builder: (context, state) =>
+                            const TestRouteMarker('setlist-view'),
+                      ),
+                      GoRoute(
+                        path: ':id/edit',
+                        name: 'edit-setlist',
+                        builder: (context, state) =>
+                            const TestRouteMarker('edit-setlist'),
+                      ),
+                    ],
+                  ),
+                ],
               ),
-              GoRoute(
-                path: ':id/edit',
-                name: 'edit-band',
-                builder: (context, state) => const TestRouteMarker('edit-band'),
-              ),
-              GoRoute(
-                path: ':id/songs',
-                name: 'band-songs',
-                builder: (context, state) =>
-                    const TestRouteMarker('band-songs'),
-              ),
-              GoRoute(
-                path: ':id/setlists',
-                name: 'band-setlists',
-                builder: (context, state) =>
-                    const TestRouteMarker('band-setlists'),
-              ),
-            ],
-          ),
-          GoRoute(
-            path: '/main/setlists',
-            name: 'setlists',
-            builder: (context, state) => const SetlistsListScreen(),
-            routes: [
-              GoRoute(
-                path: 'create',
-                name: 'create-setlist',
-                builder: (context, state) =>
-                    const TestRouteMarker('create-setlist'),
-              ),
-              GoRoute(
-                path: ':id',
-                name: 'setlist-view',
-                builder: (context, state) =>
-                    const TestRouteMarker('setlist-view'),
-              ),
-              GoRoute(
-                path: ':id/edit',
-                name: 'edit-setlist',
-                builder: (context, state) =>
-                    const TestRouteMarker('edit-setlist'),
+              StatefulShellBranch(
+                observers: [BranchStackObserver(4)],
+                routes: [
+                  GoRoute(
+                    path: '/main/profile',
+                    name: 'profile',
+                    builder: (context, state) =>
+                        const TestRouteMarker('profile'),
+                  ),
+                ],
               ),
             ],
           ),
@@ -215,6 +262,10 @@ Future<GoRouter> pumpRoutedTestApp(
   List<dynamic> overrides = const [],
   List<RouteBase>? routes,
 }) async {
+  // The menu registry is process-global; wipe it so a previous test's
+  // published items (with closures over disposed containers) can't leak in.
+  MenuScopeRegistry.reset();
+  BranchStackObserver.reset();
   final container = ProviderContainer(overrides: overrides.cast());
   final router = createRoutedTestRouter(
     initialLocation: initialLocation,

--- a/test/screens/metronome_screen_test.dart
+++ b/test/screens/metronome_screen_test.dart
@@ -92,6 +92,7 @@ void main() {
       );
       await tester.pump();
 
+      // Slim top bar + the pushed-mode bottom bar both name the screen.
       expect(find.text('Metronome'), findsOneWidget);
     });
 
@@ -384,22 +385,28 @@ void main() {
       expect(find.text('Haptics'), findsNothing);
       expect(container.read(metronomeProvider).hapticsEnabled, isTrue);
 
+      // Menu moved to the bottom bar; it opens the app menu sheet.
       await tester.tap(find.byIcon(Icons.more_horiz));
       await tester.pumpAndSettle();
 
       expect(find.text('Haptics'), findsOneWidget);
-      expect(find.text('On'), findsOneWidget);
+      expect(tester.widget<Switch>(find.byType(Switch)).value, isTrue);
 
+      // The Haptics row has a live trailing switch, so tapping it toggles in
+      // place WITHOUT closing the sheet.
       await tester.tap(find.text('Haptics'));
       await tester.pumpAndSettle();
 
       expect(container.read(metronomeProvider).hapticsEnabled, isFalse);
+      expect(find.text('Haptics'), findsOneWidget);
+      expect(tester.widget<Switch>(find.byType(Switch)).value, isFalse);
 
-      await tester.tap(find.byIcon(Icons.more_horiz));
+      // The trailing switch itself toggles back on, still in-sheet.
+      await tester.tap(find.byType(Switch));
       await tester.pumpAndSettle();
 
-      expect(find.text('Haptics'), findsOneWidget);
-      expect(find.text('Off'), findsWidgets);
+      expect(container.read(metronomeProvider).hapticsEnabled, isTrue);
+      expect(tester.widget<Switch>(find.byType(Switch)).value, isTrue);
     });
 
     testWidgets('edit song menu opens the loaded song editor', (tester) async {

--- a/test/screens/setlists/setlist_view_screen_test.dart
+++ b/test/screens/setlists/setlist_view_screen_test.dart
@@ -1,8 +1,11 @@
 import 'package:flowgroove/models/setlist.dart';
 import 'package:flowgroove/models/song.dart';
+import 'package:flowgroove/providers/auth/auth_provider.dart';
 import 'package:flowgroove/providers/data/data_providers.dart';
 import 'package:flowgroove/providers/permissions_provider.dart';
+import 'package:flowgroove/screens/main_shell.dart';
 import 'package:flowgroove/screens/setlists/setlist_view_screen.dart';
+import 'package:flowgroove/widgets/menu_items_scope.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,7 +13,8 @@ import 'package:go_router/go_router.dart';
 
 import '../../helpers/metronome_test_runtime.dart';
 import '../../helpers/mocks.dart';
-import '../../helpers/routed_test_harness.dart' show TestRouteMarker;
+import '../../helpers/routed_test_harness.dart'
+    show TestAppUserNotifier, TestRouteMarker;
 
 void main() {
   group('SetlistViewScreen', () {
@@ -41,30 +45,80 @@ void main() {
       );
     });
 
-    /// Builds a minimal router with the view screen as home plus the two
-    /// named routes it can push to, so `context.pushNamed` calls resolve
-    /// without needing the full app router.
+    /// Builds a minimal router mirroring production: the view screen is a
+    /// pushed child of the setlists branch inside the real [MainShell], so
+    /// the shell's pushed-mode bottom bar ([← Back] [Open in Metronome] [⋮])
+    /// renders. Portrait viewport, because the bottom bar only exists in
+    /// portrait (landscape uses the rail).
     Future<GoRouter> pumpView(
       WidgetTester tester, {
       bool canEdit = true,
     }) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      MenuScopeRegistry.reset();
+
       final router = GoRouter(
-        initialLocation: '/view',
+        initialLocation: '/main/setlists/view/${setlist.id}',
         routes: [
-          GoRoute(
-            path: '/view',
-            name: 'view',
-            builder: (context, state) =>
-                SetlistViewScreen(setlist: setlist),
+          StatefulShellRoute.indexedStack(
+            builder: (context, state, navigationShell) =>
+                MainShell(navigationShell: navigationShell),
+            branches: [
+              for (final root in const [
+                '/main/home',
+                '/main/songs',
+                '/main/bands',
+              ])
+                StatefulShellBranch(
+                  routes: [
+                    GoRoute(
+                      path: root,
+                      builder: (context, state) =>
+                          TestRouteMarker(root.split('/').last),
+                    ),
+                  ],
+                ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/main/setlists',
+                    name: 'setlists',
+                    builder: (context, state) =>
+                        const TestRouteMarker('setlists'),
+                    routes: [
+                      GoRoute(
+                        path: 'view/:id',
+                        name: 'view',
+                        builder: (context, state) =>
+                            SetlistViewScreen(setlist: setlist),
+                      ),
+                      GoRoute(
+                        path: ':id/edit',
+                        name: 'edit-setlist',
+                        builder: (context, state) =>
+                            const TestRouteMarker('edit-setlist'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/main/profile',
+                    name: 'profile',
+                    builder: (context, state) =>
+                        const TestRouteMarker('profile'),
+                  ),
+                ],
+              ),
+            ],
           ),
           GoRoute(
-            path: '/setlists/:id/edit',
-            name: 'edit-setlist',
-            builder: (context, state) =>
-                const TestRouteMarker('edit-setlist'),
-          ),
-          GoRoute(
-            path: '/metronome',
+            path: '/main/metronome',
             name: 'metronome',
             builder: (context, state) => const TestRouteMarker('metronome'),
           ),
@@ -74,6 +128,12 @@ void main() {
 
       final container = ProviderContainer(
         overrides: [
+          // The shell's DemoModeBanner watches appUserProvider; without an
+          // override the real notifier throws (no Firebase in tests) and
+          // Riverpod's retry timer trips the pending-timer check.
+          appUserProvider.overrideWith(
+            () => TestAppUserNotifier(MockDataHelper.createMockAppUser()),
+          ),
           songsProvider.overrideWith((ref) => Stream<List<Song>>.value(songs)),
           setlistsProvider.overrideWith(
             (ref) => Stream<List<Setlist>>.value([setlist]),
@@ -128,9 +188,13 @@ void main() {
     ) async {
       await pumpView(tester);
 
-      expect(find.text('Edit'), findsOneWidget);
+      // Edit moved into the bottom bar's Menu sheet.
+      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Edit'));
+      expect(find.text('Edit Setlist'), findsOneWidget);
+
+      await tester.tap(find.text('Edit Setlist'));
       await tester.pumpAndSettle();
 
       expect(find.text('route:edit-setlist'), findsOneWidget);
@@ -141,7 +205,9 @@ void main() {
     ) async {
       await pumpView(tester, canEdit: false);
 
-      expect(find.text('Edit'), findsNothing);
+      // No menu items at all -> the bottom bar hides the ⋮ Menu button.
+      expect(find.byIcon(Icons.more_horiz), findsNothing);
+      expect(find.text('Edit Setlist'), findsNothing);
     });
 
     testWidgets('pushes the metronome screen from the primary action button', (

--- a/test/screens/setlists/setlists_list_screen_test.dart
+++ b/test/screens/setlists/setlists_list_screen_test.dart
@@ -37,7 +37,8 @@ void main() {
         overrides: overridesFor(setlists: Stream<List<Setlist>>.value([])),
       );
 
-      expect(find.text('Setlists'), findsOneWidget);
+      // Slim top bar title + the shell's Setlists nav tab label.
+      expect(find.text('Setlists'), findsNWidgets(2));
       expect(find.text('Search setlists...'), findsOneWidget);
       expect(find.byIcon(Icons.sort), findsOneWidget);
     });

--- a/test/screens/songs/songs_list_screen_test.dart
+++ b/test/screens/songs/songs_list_screen_test.dart
@@ -77,7 +77,8 @@ void main() {
         overrides: overridesFor(songs: Stream<List<Song>>.value([])),
       );
 
-      expect(find.text('Songs'), findsOneWidget);
+      // Slim top bar title + the shell's Songs nav tab label.
+      expect(find.text('Songs'), findsNWidgets(2));
       expect(find.text('Search songs...'), findsOneWidget);
       expect(find.text('Filters:'), findsOneWidget);
       expect(find.byIcon(Icons.sort), findsOneWidget);
@@ -130,7 +131,8 @@ void main() {
       expect(find.text('130 BPM'), findsOneWidget);
       expect(find.text('G'), findsOneWidget);
       // Song cards deliberately have no leading icon — text gets the room.
-      expect(find.byIcon(Icons.music_note), findsNothing);
+      // (The single match is the shell's selected Songs nav tab icon.)
+      expect(find.byIcon(Icons.music_note), findsOneWidget);
       expect(find.byTooltip('More'), findsNWidgets(2));
       expect(find.byTooltip('Metronome'), findsNWidgets(2));
 

--- a/test/utils/snackbar_undo_test.dart
+++ b/test/utils/snackbar_undo_test.dart
@@ -1,0 +1,157 @@
+import 'package:flowgroove/utils/snackbar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('showAppSnackBar - Action Rendering', () {
+    testWidgets('renders snackbar with action when both actionLabel and onAction provided',
+        (WidgetTester tester) async {
+      bool actionCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () {
+                  showAppSnackBar(
+                    context,
+                    'Test message',
+                    actionLabel: 'Undo',
+                    onAction: () {
+                      actionCalled = true;
+                    },
+                  );
+                },
+                child: const Text('Show SnackBar'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Trigger the snackbar
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      // Verify message is displayed
+      expect(find.text('Test message'), findsOneWidget);
+
+      // Verify action button is displayed
+      expect(find.text('Undo'), findsOneWidget);
+
+      // Tap the action button
+      await tester.tap(find.text('Undo'));
+      await tester.pumpAndSettle();
+
+      // Verify callback was called
+      expect(actionCalled, true);
+    });
+
+    testWidgets('renders snackbar without action when only message provided',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () {
+                  showAppSnackBar(context, 'Test message');
+                },
+                child: const Text('Show SnackBar'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Trigger the snackbar
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      // Verify message is displayed
+      expect(find.text('Test message'), findsOneWidget);
+
+      // Verify no action button is present
+      expect(find.byType(SnackBarAction), findsNothing);
+    });
+
+    testWidgets('uses longer duration when action is present',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () {
+                  showAppSnackBar(
+                    context,
+                    'Test message',
+                    actionLabel: 'Undo',
+                    onAction: () {},
+                  );
+                },
+                child: const Text('Show SnackBar'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Trigger the snackbar
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      // Find the SnackBar and verify duration
+      final SnackBar snackBar = find
+          .byType(SnackBar)
+          .evaluate()
+          .single
+          .widget as SnackBar;
+
+      expect(snackBar.duration, const Duration(seconds: 5));
+    });
+
+    testWidgets('ignores onAction if actionLabel is null',
+        (WidgetTester tester) async {
+      bool actionCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () {
+                  showAppSnackBar(
+                    context,
+                    'Test message',
+                    onAction: () {
+                      actionCalled = true;
+                    },
+                  );
+                },
+                child: const Text('Show SnackBar'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Trigger the snackbar
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      // Verify message is displayed
+      expect(find.text('Test message'), findsOneWidget);
+
+      // Verify no action button is present (actionLabel was null)
+      expect(find.byType(SnackBarAction), findsNothing);
+
+      // Wait for snackbar to disappear
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      // Verify callback was NOT called
+      expect(actionCalled, false);
+    });
+  });
+}

--- a/test/widgets/song_constructor_test.dart
+++ b/test/widgets/song_constructor_test.dart
@@ -160,7 +160,8 @@ void main() {
       expect(capturedSections!.first.name, equals('Bridge'));
     });
 
-    testWidgets('delete section removes from list', (tester) async {
+    testWidgets('delete section removes from list and shows undo snackbar',
+        (tester) async {
       final sections = [Section(id: '1', name: 'Intro')];
 
       List<Section>? capturedSections;
@@ -183,12 +184,23 @@ void main() {
       await tester.tap(find.byKey(const Key('section_delete_1')).hitTestable());
       await tester.pumpAndSettle();
 
-      // Confirm deletion
-      await tester.tap(find.widgetWithText(ElevatedButton, 'Delete'));
-      await tester.pumpAndSettle();
-
+      // Section should be deleted immediately (no dialog confirmation)
       expect(capturedSections, isNotNull);
       expect(capturedSections!.isEmpty, isTrue);
+
+      // Snackbar should appear with undo message
+      expect(find.text('Section "Intro" deleted'), findsOneWidget);
+      expect(find.text('Undo'), findsOneWidget);
+
+      // Tap Undo to restore the section
+      await tester.tap(find.text('Undo'));
+      await tester.pumpAndSettle();
+
+      // Section should be restored at original index
+      expect(capturedSections, isNotNull);
+      expect(capturedSections!.length, equals(1));
+      expect(capturedSections!.first.id, equals('1'));
+      expect(capturedSections!.first.name, equals('Intro'));
     });
 
     testWidgets('auto-generate creates sections', (tester) async {

--- a/test/widgets/tools/tool_scaffold_test.dart
+++ b/test/widgets/tools/tool_scaffold_test.dart
@@ -1,5 +1,6 @@
 import 'package:flowgroove/services/connectivity_service.dart';
 import 'package:flowgroove/theme/mono_pulse_theme.dart';
+import 'package:flowgroove/widgets/app_menu_sheet.dart';
 import 'package:flowgroove/widgets/offline_indicator.dart';
 import 'package:flowgroove/widgets/tools/tool_scaffold.dart';
 import 'package:flutter/material.dart';
@@ -37,6 +38,7 @@ void main() {
         const ToolScreenScaffold(title: 'Metronome', mainWidget: SizedBox()),
       );
 
+      // Slim top bar + the pushed-mode bottom bar both name the screen.
       expect(find.text('Metronome'), findsOneWidget);
     });
 
@@ -160,8 +162,8 @@ void main() {
       tester,
     ) async {
       final menuItems = [
-        const PopupMenuItem<void>(value: 'save', child: Text('Save')),
-        const PopupMenuItem<void>(value: 'settings', child: Text('Settings')),
+        AppMenuItem(icon: Icons.save, label: 'Save', onTap: () {}),
+        AppMenuItem(icon: Icons.settings, label: 'Settings', onTap: () {}),
       ];
 
       await _pumpToolScaffold(
@@ -209,7 +211,8 @@ void main() {
 
       final columnFinder = find.byType(Column);
       expect(columnFinder, findsWidgets);
-      expect(find.byType(Expanded), findsOneWidget);
+      // Body Expanded (main widget) + the bottom action bar's three slots.
+      expect(find.byType(Expanded), findsWidgets);
     });
 
     testWidgets('renders with SafeArea', (tester) async {


### PR DESCRIPTION
Phase 5 of the UX-audit remediation — the navigation redesign. **Stacked on #103** (merge order #101 → #102 → #103 → this).

## What changes for the user
- **Bottom bar, two states.** Tab roots: `[Home][Songs][Bands][Setlists][⋮ Menu]` — Menu opens a bottom sheet (screen-name header, the screen's actions, then a Profile row with avatar). Pushed screens: `[← Back]···[⋮]`, with an optional primary-action slot (SetlistView shows Open in Metronome there). Same bar for branch children and root-pushed tools.
- **Top bars are slim titles only** — zero interactive controls in the top 15% of the screen (Fitts: was 2 expensive-corner targets on every screen). In-app Back now exists on **web/PWA** where there is no system back (Nielsen H3).
- **Undo snackbars** (single-level, 5s, thumb zone) for section delete (replaces the confirm dialog), setlist delete, song-removed-from-setlist, practice-song unload. Member removal keeps its confirm dialog — server-authoritative, not client-reversible.
- Metronome/Tuner menus moved into the sheet with **live toggles** and values folded into labels ("Sound: Click", "Count-in: Off") — also resolves the audit's menu-value mismatch note (P2-8).

## Engineering notes
- Pushed-mode detection = `BranchStackObserver` (per-branch NavigatorObservers counting PageRoutes; PopupRoutes excluded so the sheet itself can't flip the bar) **OR** non-root URI (deep entries). go_router's `currentConfiguration.uri` provably never updates for intra-branch pushes — found on device after 1942 tests passed with the URI-only approach.
- Menu data flows through `MenuScopeRegistry`: post-frame publications (no build-phase writes — the P0-3 lesson), location map for roots + identity-keyed stack for pushed screens (dispose-order safe).
- Deferred (documented in code/plan): three `Navigator.push`ed screens (performance sheet, song editor, API access) keep a top back until migrated to routes; add-song's Save bar still stacks; landscape rail has no primary-action slot.

## Verification
- `flutter analyze` 0 errors · full suite **1942 passed, exit 0 (pipefail)** · `flutter build web` compile check
- Device (release build over existing app): root Menu sheet w/ actions+Profile ✅ · Profile via sheet + Menu slot highlight ✅ · pushed bar on Edit Song ✅ · section delete → **Undo restores at original index** ✅ · Metronome sheet w/ live Haptics toggle ✅ · deep-entry and back flows ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)