### PR TITLE
feat(export): song editor Export PDF + ChordPro (#79)

### DIFF
--- a/lib/screens/songs/song_editor_screen.dart
+++ b/lib/screens/songs/song_editor_screen.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../models/section.dart';
+import '../../services/export/chordpro_export.dart';
+import '../../services/export/pdf_service.dart';
+import '../../services/export/setlist_export_sheet.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/chordpro.dart';
+import '../../utils/snackbar.dart';
 import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/bottom_nav_or_action_bar.dart';
 import 'chordpro_sync_controller.dart';
@@ -188,6 +192,38 @@ class _SongEditorScreenState extends State<SongEditorScreen> {
     );
   }
 
+  String get _exportTitle {
+    final t = _sync.meta.title;
+    return (t?.isNotEmpty ?? false) ? t! : widget.title;
+  }
+
+  Future<void> _exportPdf() async {
+    final layout = await pickSongSheetPdfLayout(context);
+    if (layout == null) return;
+    final m = _sync.meta;
+    try {
+      await PdfService.exportSongSheet(
+        _exportTitle,
+        _sync.sections,
+        songKey: m.ourKey,
+        bpm: m.ourBpm,
+        timeTop: m.timeTop,
+        fitOnePage: layout == SetlistPdfLayout.compact,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      showAppSnackBar(context, 'PDF export failed: $e');
+    }
+  }
+
+  Future<void> _exportChordPro() async {
+    _sync.flushPending();
+    final ok = await shareChordProText(_sync.text, _exportTitle);
+    if (!ok && mounted) {
+      showAppSnackBar(context, 'ChordPro export failed');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final m = _sync.meta;
@@ -249,6 +285,16 @@ class _SongEditorScreenState extends State<SongEditorScreen> {
                 icon: Icons.playlist_add,
                 label: 'Import lyrics & chords',
                 onTap: _import,
+              ),
+              AppMenuItem(
+                icon: Icons.picture_as_pdf_outlined,
+                label: 'Export PDF',
+                onTap: _exportPdf,
+              ),
+              AppMenuItem(
+                icon: Icons.description_outlined,
+                label: 'Export ChordPro',
+                onTap: _exportChordPro,
               ),
             ],
           ),

--- a/lib/services/export/chordpro_export.dart
+++ b/lib/services/export/chordpro_export.dart
@@ -9,10 +9,14 @@ import '../../utils/chordpro.dart';
 /// Exports a song's "our version" as a standard ChordPro `.cho` file and opens
 /// the share sheet. Reuses [songToChordPro] (directives + `[Chord]lyric` lines)
 /// and the same share_plus path as the CSV export.
-Future<bool> shareSongChordPro(Song song) async {
+Future<bool> shareSongChordPro(Song song) =>
+    shareChordProText(songToChordPro(song), song.title);
+
+/// Shares an already-serialized ChordPro document (e.g. the song editor's live
+/// text) as a `.cho` file. (#79 — export from the editor menu.)
+Future<bool> shareChordProText(String text, String title) async {
   try {
-    final text = songToChordPro(song);
-    final fileName = '${_sanitize(song.title)}.cho';
+    final fileName = '${_sanitize(title)}.cho';
     await SharePlus.instance.share(
       ShareParams(
         files: [
@@ -23,7 +27,7 @@ Future<bool> shareSongChordPro(Song song) async {
           ),
         ],
         fileNameOverrides: [fileName],
-        subject: 'FlowGroove — ${song.title}',
+        subject: 'FlowGroove — $title',
       ),
     );
     return true;

--- a/test/screens/songs/song_editor_export_test.dart
+++ b/test/screens/songs/song_editor_export_test.dart
@@ -1,0 +1,84 @@
+import 'package:flowgroove/models/section.dart';
+import 'package:flowgroove/screens/songs/song_editor_screen.dart';
+import 'package:flowgroove/services/export/pdf_service.dart';
+import 'package:flowgroove/services/export/setlist_export_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpEditor(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SongEditorScreen(
+          title: 'Test Song',
+          sections: [Section(id: 's1', name: 'Verse', duration: 2)],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('Song editor export menu (#79)', () {
+    testWidgets('menu offers Export PDF and Export ChordPro', (tester) async {
+      await pumpEditor(tester);
+
+      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Export PDF'), findsOneWidget);
+      expect(find.text('Export ChordPro'), findsOneWidget);
+      // Pre-existing items stay.
+      expect(find.text('Add section'), findsOneWidget);
+      expect(find.text('Import lyrics & chords'), findsOneWidget);
+    });
+
+    testWidgets('Export PDF opens the song-sheet layout picker', (
+      tester,
+    ) async {
+      await pumpEditor(tester);
+
+      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Export PDF'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('As is'), findsOneWidget);
+      expect(find.text('Compact'), findsOneWidget);
+      expect(find.text('Fit everything on one A4 page'), findsOneWidget);
+    });
+  });
+
+  group('pickSongSheetPdfLayout', () {
+    Future<SetlistPdfLayout?> pickVia(
+      WidgetTester tester,
+      String option,
+    ) async {
+      SetlistPdfLayout? picked;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                picked = await pickSongSheetPdfLayout(context);
+              },
+              child: const Text('pick'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('pick'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(option));
+      await tester.pumpAndSettle();
+      return picked;
+    }
+
+    testWidgets('"As is" returns detailed', (tester) async {
+      expect(await pickVia(tester, 'As is'), SetlistPdfLayout.detailed);
+    });
+
+    testWidgets('"Compact" returns compact (fit one A4)', (tester) async {
+      expect(await pickVia(tester, 'Compact'), SetlistPdfLayout.compact);
+    });
+  });
+}


### PR DESCRIPTION
Closes #79.

Exploration showed the issue's core ask already shipped with the audit Phase-6 sweep: the performance sheet has "Export PDF" with the **As is / Compact (fit everything on one A4 page)** picker (`pickSongSheetPdfLayout` → `PdfService.exportSongSheet(fitOnePage:)`) and "Export ChordPro". What was missing: the **song editor's** menu had no export at all ("right now on this screen there are no").

- Song editor menu: adds **Export PDF** (same layout picker, exports the editor's live sections/meta) and **Export ChordPro** (shares the editor's ChordPro text directly).
- `chordpro_export.dart`: new `shareChordProText(text, title)`; `shareSongChordPro` now delegates to it.
- Tests: editor menu items + picker flow + `pickSongSheetPdfLayout` returns (4 new). Full suite green (1963), analyze 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)