### PR TITLE
feat(ai-import): seeded AI prompt + JSON paste + schema doc (#72 #73)

### DIFF
--- a/SONG_JSON_SCHEMA.md
+++ b/SONG_JSON_SCHEMA.md
@@ -1,0 +1,66 @@
+# FlowGroove Song JSON — schema v1
+
+The stable import/export format that the in-app JSON import, the AI prompt
+templates (#73), and the MCP tools (#74) all write against. Implementations
+that MUST stay in sync with this document:
+
+- Dart: `lib/services/json/song_json_codec.dart` (`SongJsonCodec`)
+- Server: `functions/src/mcp/song_schema.js` (`validateSong`)
+- Prompt: `lib/services/json/song_ai_prompt.dart` (`songImportPrompt`)
+
+## Envelope
+
+```json
+{
+  "schemaVersion": 1,
+  "songs": [ { "title": "…", "artist": "…" } ]
+}
+```
+
+For convenience, `SongJsonCodec.parse` also accepts a bare song array or a
+single bare song object. An unknown `schemaVersion` produces a warning and a
+best-effort import, not a failure.
+
+## Song fields
+
+| Field | Type | Rules |
+|---|---|---|
+| `title` | string | **required**, non-empty |
+| `artist` | string | optional |
+| `originalKey`, `ourKey` | string | matches `^[A-G][#b]?m?$` — e.g. `C`, `G#`, `Am`, `Bbm`; invalid → field error |
+| `originalBPM`, `ourBPM` | integer | 40–300; invalid → field error |
+| `notes` | string | free text |
+| `tags` | string[] | non-strings dropped |
+| `spotifyUrl` | string | must be a valid URL |
+| `links` | object[] | `{ "url", … }` per `Link.toJson`; invalid url → entry dropped with error |
+| `sections` | object[] | see below |
+| `spotifyId`, `musicbrainzId`, `isrc`, `album` | string | provenance/identity, passed through |
+| `durationMs` | integer | passed through |
+| `id` | string | accepted on input but a fresh id is always generated |
+
+Unknown fields are ignored with a warning naming them.
+
+## Section shape
+
+```json
+{
+  "name": "Verse 1",
+  "duration": 4,
+  "notes": "palm-muted",
+  "chordChart": "[Am]Twinkle [F]little [C]star",
+  "colorValue": 4283215696,
+  "id": "optional — regenerated if absent"
+}
+```
+
+- `name` defaults to `"Section"`, `duration` (bars, int) defaults to 1.
+- `chordChart` is **ChordPro**: lyric lines with the chord in square brackets
+  immediately before its syllable. Directives are not expected inside
+  `chordChart` (section identity lives in `name`).
+
+## Error model
+
+`SongJsonCodec.parse` returns `SongParseResult`: `successful` (parsed songs),
+`errors` (per-song, field-level; a song with a missing title is skipped),
+`warnings` (unknown fields, unknown schemaVersion). The server-side
+`validateSong` mirrors the same rules and rejects writes that fail them.

--- a/functions/src/mcp/song_schema.js
+++ b/functions/src/mcp/song_schema.js
@@ -1,5 +1,5 @@
 /**
- * Server-side validator for FlowGroove Song JSON (see docs/SONG_JSON_SCHEMA.md).
+ * Server-side validator for FlowGroove Song JSON (see SONG_JSON_SCHEMA.md at repo root).
  * Mirrors the Dart client validator (lib/services/json/song_json_codec.dart) against
  * the same documented schema.
  * ponytail: two small validators, one documented schema. Promote to a shared

--- a/lib/screens/songs/add_song_screen.dart
+++ b/lib/screens/songs/add_song_screen.dart
@@ -417,10 +417,14 @@ class _AddSongScreenState extends ConsumerState<AddSongScreen>
   /// Opens the paste-import sheet and applies the result (metadata + sections)
   /// to the form, appending the parsed sections to any existing ones.
   Future<void> _importLyrics() async {
+    final form = ref.read(songFormStateProvider).formData;
     final imported = await showModalBottomSheet<ImportedSong>(
       context: context,
       isScrollControlled: true,
-      builder: (_) => const ImportLyricsDialog(),
+      builder: (_) => ImportLyricsDialog(
+        seedTitle: form.title,
+        seedArtist: form.artist,
+      ),
     );
     if (imported == null || !mounted) return;
     _applyImported(imported);

--- a/lib/screens/songs/components/import_lyrics_dialog.dart
+++ b/lib/screens/songs/components/import_lyrics_dialog.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../../models/section.dart';
 import '../../../models/song.dart';
+import '../../../services/json/song_ai_prompt.dart';
+import '../../../services/json/song_json_codec.dart';
 import '../../../theme/mono_pulse_theme.dart';
 import '../../../utils/chordpro.dart';
+import '../../../utils/snackbar.dart';
 import '../../../widgets/chord_chart_view.dart';
 
 /// Result of the paste-import sheet: the sections plus any song-level metadata
@@ -41,7 +45,12 @@ class ImportedSong {
 /// sections all sync to the form; looser lyrics fall back to [parseSongSections]
 /// for section-splitting only.
 class ImportLyricsDialog extends StatefulWidget {
-  const ImportLyricsDialog({super.key});
+  const ImportLyricsDialog({super.key, this.seedTitle, this.seedArtist});
+
+  /// Pre-typed title/artist from the caller's form — seeds the "Copy AI
+  /// prompt" template (#73) so the user's AI is asked about the right song.
+  final String? seedTitle;
+  final String? seedArtist;
 
   @override
   State<ImportLyricsDialog> createState() => _ImportLyricsDialogState();
@@ -67,6 +76,23 @@ class _ImportLyricsDialogState extends State<ImportLyricsDialog> {
 
   ImportedSong get _parsed {
     final text = _controller.text;
+
+    // A pasted AI answer in Song JSON (#73): valid JSON wins, otherwise fall
+    // through — a ChordPro doc also starts with '{' but never decodes as JSON.
+    final trimmed = text.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      final r = const SongJsonCodec().parse(trimmed);
+      if (r.successful.isNotEmpty) {
+        final s = r.successful.first;
+        return ImportedSong(
+          sections: s.sections,
+          title: s.title.isNotEmpty ? s.title : null,
+          artist: s.artist.isNotEmpty ? s.artist : null,
+          ourKey: s.ourKey,
+          ourBpm: s.ourBPM,
+        );
+      }
+    }
 
     // A doc with directives → full ChordPro sync (metadata + structured sections).
     // ponytail: the `{` heuristic is enough; looser lyric pastes have none.
@@ -104,6 +130,22 @@ class _ImportLyricsDialogState extends State<ImportLyricsDialog> {
   }
 
   void _import() => Navigator.pop(context, _parsed);
+
+  Future<void> _copyAiPrompt() async {
+    await Clipboard.setData(
+      ClipboardData(
+        text: songImportPrompt(
+          title: widget.seedTitle,
+          artist: widget.seedArtist,
+        ),
+      ),
+    );
+    if (!mounted) return;
+    showAppSnackBar(
+      context,
+      'AI prompt copied — paste it to your AI, then paste its answer here',
+    );
+  }
 
   String _metaLine(ImportedSong p) => [
     if (p.title != null) '“${p.title}”',
@@ -190,8 +232,13 @@ class _ImportLyricsDialogState extends State<ImportLyricsDialog> {
             ],
             const SizedBox(height: 8),
             Row(
-              mainAxisAlignment: MainAxisAlignment.end,
               children: [
+                TextButton.icon(
+                  onPressed: _copyAiPrompt,
+                  icon: const Icon(Icons.auto_awesome, size: 18),
+                  label: const Text('Copy AI prompt'),
+                ),
+                const Spacer(),
                 TextButton(
                   onPressed: () => Navigator.pop(context),
                   child: const Text('Cancel'),

--- a/lib/screens/songs/song_editor_screen.dart
+++ b/lib/screens/songs/song_editor_screen.dart
@@ -140,10 +140,14 @@ class _SongEditorScreenState extends State<SongEditorScreen> {
   }
 
   Future<void> _import() async {
+    final meta = _sync.meta;
     final imported = await showModalBottomSheet<ImportedSong>(
       context: context,
       isScrollControlled: true,
-      builder: (_) => const ImportLyricsDialog(),
+      builder: (_) => ImportLyricsDialog(
+        seedTitle: meta.title,
+        seedArtist: meta.artist,
+      ),
     );
     if (imported == null || imported.sections.isEmpty || !mounted) return;
 

--- a/lib/services/json/song_json_codec.dart
+++ b/lib/services/json/song_json_codec.dart
@@ -11,7 +11,7 @@ import '../csv/song_csv_schema.dart' show SongCsvValidation;
 /// FlowGroove **Song JSON v1** — the stable, documented import/export format that
 /// AI prompt templates (#73) and the MCP endpoint (#74) write against.
 ///
-/// Schema: `docs/SONG_JSON_SCHEMA.md`. Envelope:
+/// Schema: `SONG_JSON_SCHEMA.md` (repo root). Envelope:
 /// `{ "schemaVersion": 1, "songs": [ {song}, ... ] }`. [parse] also accepts a bare
 /// song array or a single song object for convenience.
 class SongJsonCodec {

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -57,7 +57,7 @@ Gemini CLI / other MCP clients use the same `command` + `args` + `env` shape.
 | `create_song` | write | Add a song from FlowGroove Song JSON. |
 | `update_song` | write | Update a song by id. |
 
-Song shape: see [`docs/SONG_JSON_SCHEMA.md`](../docs/SONG_JSON_SCHEMA.md) — `sections[].chordChart`
+Song shape: see [`SONG_JSON_SCHEMA.md`](../SONG_JSON_SCHEMA.md) — `sections[].chordChart`
 is ChordPro (`[Am]Twinkle [F]star`). Writes are validated server-side and scoped to your
 own library; there are no canonical or delete operations.
 

--- a/test/screens/songs/import_lyrics_dialog_test.dart
+++ b/test/screens/songs/import_lyrics_dialog_test.dart
@@ -1,0 +1,126 @@
+import 'package:flowgroove/screens/songs/components/import_lyrics_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final resultHolder = <Future<ImportedSong?>>[];
+
+  Future<void> pumpAndOpen(
+    WidgetTester tester, {
+    String? seedTitle,
+    String? seedArtist,
+  }) async {
+    resultHolder.clear();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () {
+                resultHolder.add(
+                  showModalBottomSheet<ImportedSong>(
+                    context: context,
+                    isScrollControlled: true,
+                    builder: (_) => ImportLyricsDialog(
+                      seedTitle: seedTitle,
+                      seedArtist: seedArtist,
+                    ),
+                  ),
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('ImportLyricsDialog JSON paste (#73)', () {
+    testWidgets('valid Song JSON parses to sections + metadata', (
+      tester,
+    ) async {
+      await pumpAndOpen(tester);
+
+      const jsonText = '''
+{ "schemaVersion": 1, "songs": [ {
+  "title": "Test Song", "artist": "Test Band", "ourKey": "Am", "ourBPM": 120,
+  "sections": [ { "name": "Verse 1", "duration": 4,
+                  "chordChart": "[Am]hello [F]world" } ]
+} ] }''';
+      await tester.enterText(find.byType(TextField), jsonText);
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Test Song'), findsWidgets);
+      expect(find.text('Verse 1'), findsWidgets);
+
+      await tester.ensureVisible(find.text('Import 1'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Import 1'));
+      await tester.pumpAndSettle();
+      expect(
+        find.byType(ImportLyricsDialog),
+        findsNothing,
+        reason: 'sheet should pop on Import',
+      );
+      final imported = await resultHolder.single;
+      expect(imported!.title, 'Test Song');
+      expect(imported.artist, 'Test Band');
+      expect(imported.ourKey, 'Am');
+      expect(imported.ourBpm, 120);
+      expect(imported.sections.single.chordChart, '[Am]hello [F]world');
+    });
+
+    testWidgets('ChordPro paste still parses (regression)', (tester) async {
+      await pumpAndOpen(tester);
+
+      await tester.enterText(
+        find.byType(TextField),
+        '{title: My Song}\n{key: Dm}\n'
+        '{start_of_verse: Verse 1}\n[Dm]line\n{end_of_verse}',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('My Song'), findsWidgets);
+      expect(find.text('Verse 1'), findsWidgets);
+    });
+
+    testWidgets('Copy AI prompt copies a seeded prompt', (tester) async {
+      final copied = <String>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied.add((call.arguments as Map)['text'] as String);
+          }
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+
+      await pumpAndOpen(
+        tester,
+        seedTitle: 'Hey Joe',
+        seedArtist: 'Jimi Hendrix',
+      );
+
+      await tester.ensureVisible(find.text('Copy AI prompt'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Copy AI prompt'));
+      await tester.pumpAndSettle();
+
+      expect(copied, hasLength(1));
+      expect(copied.single, contains('"Hey Joe"'));
+      expect(copied.single, contains('"Jimi Hendrix"'));
+      expect(copied.single, contains('schemaVersion'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #72, closes #73. Last code gaps of epic #56 (MCP half tracked in #74/#77).

Exploration showed the AI-import epic mostly shipped already: ChordPro/plain-text paste→draft lives in `ImportLyricsDialog` (wired into add-song and the song editor), and `songImportPrompt` existed with copy-to-clipboard in the CSV/JSON dialog. This PR closes what was missing:

- **Seeded prompt (#73):** "Copy AI prompt" button in the paste dialog, seeded with the current form's title/artist from both callers.
- **JSON round-trip (#72/#73):** the paste dialog now accepts a pasted Song JSON answer via `SongJsonCodec` — valid JSON wins, otherwise ChordPro/plain-text parse unchanged. Prompt → your AI → paste back, all in one sheet.
- **`SONG_JSON_SCHEMA.md`:** written at repo root; it was referenced by `song_json_codec.dart`, `mcp/README.md`, and `functions/src/mcp/song_schema.js` but never existed. References fixed.

Tests: 3 new (JSON paste parses to sections+meta, ChordPro regression, seeded clipboard content). Full suite green (1962), analyze 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)