### PR TITLE
feat(reminders): rehearsal reminders + #57 spike conclusion

### DIFF
--- a/functions/src/telegram/reminders.js
+++ b/functions/src/telegram/reminders.js
@@ -36,24 +36,57 @@ exports.onBandSetlistCreated = functions.firestore
  */
 exports.dailyEventReminder = functions.pubsub
   .schedule("every 24 hours")
-  .onRun(async () => {
-    const now = new Date();
-    const soon = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  .onRun(() => runDailyEventReminder());
 
-    const snap = await db
-      .collectionGroup("setlists")
-      .where("eventDateTime", ">=", now.toISOString())
-      .where("eventDateTime", "<=", soon.toISOString())
-      .get();
+/** Core scan, injectable for tests: `notify(bandId, text)`, `now`. */
+async function runDailyEventReminder({
+  notify = notifyBandMembers,
+  now = new Date(),
+} = {}) {
+  const soon = new Date(now.getTime() + 24 * 60 * 60 * 1000);
 
-    for (const doc of snap.docs) {
-      const bandId = doc.ref.parent.parent && doc.ref.parent.parent.id;
-      if (!bandId) continue;
-      const data = doc.data();
-      const name = data.name || "Event";
-      const text = `⏰ *Reminder:* "${name}" is coming up in the next 24 hours.`;
-      await notifyBandMembers(bandId, text);
-    }
+  const snap = await db
+    .collectionGroup("setlists")
+    .where("eventDateTime", ">=", now.toISOString())
+    .where("eventDateTime", "<=", soon.toISOString())
+    .get();
 
-    return null;
-  });
+  for (const doc of snap.docs) {
+    const bandId = doc.ref.parent.parent && doc.ref.parent.parent.id;
+    if (!bandId) continue;
+    const data = doc.data();
+    const name = data.name || "Event";
+    const text = `⏰ *Reminder:* "${name}" is coming up in the next 24 hours.`;
+    await notify(bandId, text);
+  }
+
+  // Confirmed rehearsals starting within the window (#57). The confirmed
+  // slot's startTime lives inside the candidateSlots array, so the window
+  // check happens in code; confirmed rehearsals per band are few.
+  const rehearsals = await db
+    .collectionGroup("rehearsals")
+    .where("status", "==", "confirmed")
+    .get();
+
+  for (const doc of rehearsals.docs) {
+    const bandId = doc.ref.parent.parent && doc.ref.parent.parent.id;
+    if (!bandId) continue;
+    const data = doc.data();
+    const slot = (data.candidateSlots || []).find(
+      (s) => s && s.id === data.confirmedSlotId,
+    );
+    if (!slot || !slot.startTime) continue;
+    const start = new Date(slot.startTime);
+    if (isNaN(start) || start < now || start > soon) continue;
+    const title = data.title || "Rehearsal";
+    const where = data.location ? ` at ${data.location}` : "";
+    const text =
+      `🥁 *Rehearsal reminder:* "${title}"${where} ` +
+      `is coming up in the next 24 hours.`;
+    await notify(bandId, text);
+  }
+
+  return null;
+}
+
+exports.runDailyEventReminder = runDailyEventReminder;

--- a/functions/test/tg-db-reminders.test.js
+++ b/functions/test/tg-db-reminders.test.js
@@ -1,0 +1,116 @@
+const assert = require("node:assert/strict");
+const admin = require("firebase-admin");
+
+const projectId = "repsync-app-callable-test";
+process.env.GCLOUD_PROJECT = process.env.GCLOUD_PROJECT || projectId;
+process.env.FIREBASE_CONFIG =
+  process.env.FIREBASE_CONFIG || JSON.stringify({ projectId });
+
+const { runDailyEventReminder } = require("../src/telegram/reminders");
+const db = admin.firestore();
+
+async function clearAll() {
+  for (const name of ["bands"]) {
+    const snap = await db.collection(name).get();
+    for (const d of snap.docs) {
+      for (const sub of ["setlists", "rehearsals"]) {
+        const subSnap = await d.ref.collection(sub).get();
+        await Promise.all(subSnap.docs.map((x) => x.ref.delete()));
+      }
+      await d.ref.delete();
+    }
+  }
+}
+
+describe("runDailyEventReminder (#57)", function () {
+  this.timeout(20000);
+  beforeEach(clearAll);
+  after(clearAll);
+
+  const now = new Date("2026-07-16T12:00:00Z");
+  const inTwelveHours = new Date("2026-07-17T00:00:00Z").toISOString();
+  const inTwoDays = new Date("2026-07-18T12:00:00Z").toISOString();
+
+  it("notifies for a confirmed rehearsal within 24h, skips others", async () => {
+    await db.collection("bands").doc("b1").set({ memberUids: [] });
+    const rehearsals = db.collection("bands").doc("b1").collection("rehearsals");
+
+    await rehearsals.doc("r-soon").set({
+      title: "Full run-through",
+      location: "Garage",
+      status: "confirmed",
+      confirmedSlotId: "s1",
+      candidateSlots: [
+        { id: "s1", startTime: inTwelveHours, endTime: inTwelveHours },
+      ],
+    });
+    await rehearsals.doc("r-later").set({
+      title: "Next week",
+      status: "confirmed",
+      confirmedSlotId: "s1",
+      candidateSlots: [{ id: "s1", startTime: inTwoDays, endTime: inTwoDays }],
+    });
+    await rehearsals.doc("r-collecting").set({
+      title: "Still voting",
+      status: "collecting",
+      candidateSlots: [
+        { id: "s1", startTime: inTwelveHours, endTime: inTwelveHours },
+      ],
+    });
+
+    const sent = [];
+    await runDailyEventReminder({
+      now,
+      notify: async (bandId, text) => sent.push({ bandId, text }),
+    });
+
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].bandId, "b1");
+    assert.match(sent[0].text, /Rehearsal reminder/);
+    assert.match(sent[0].text, /Full run-through/);
+    assert.match(sent[0].text, /Garage/);
+  });
+
+  it("still notifies for setlist events within 24h", async () => {
+    await db.collection("bands").doc("b2").set({ memberUids: [] });
+    await db
+      .collection("bands")
+      .doc("b2")
+      .collection("setlists")
+      .doc("sl1")
+      .set({ name: "Club gig", eventDateTime: inTwelveHours });
+
+    const sent = [];
+    await runDailyEventReminder({
+      now,
+      notify: async (bandId, text) => sent.push({ bandId, text }),
+    });
+
+    assert.equal(sent.length, 1);
+    assert.match(sent[0].text, /Club gig/);
+  });
+
+  it("ignores rehearsals whose confirmed slot is missing", async () => {
+    await db.collection("bands").doc("b3").set({ memberUids: [] });
+    await db
+      .collection("bands")
+      .doc("b3")
+      .collection("rehearsals")
+      .doc("r-broken")
+      .set({
+        title: "Broken",
+        status: "confirmed",
+        confirmedSlotId: "nope",
+        candidateSlots: [
+          { id: "s1", startTime: inTwelveHours, endTime: inTwelveHours },
+        ],
+      });
+
+    const sent = [];
+    await runDailyEventReminder({
+      now,
+      notify: async (bandId, text) => sent.push({ bandId, text }),
+    });
+    assert.equal(sent.length, 0);
+  });
+});


### PR DESCRIPTION
Closes #57 (spike).

**Spike verdict: the minimal scheduler already exists.** Exploration confirmed the full availability-poll loop is implemented and live: candidate time slots (`CandidateSlot`), per-member Can/Maybe/Can't votes owned by each member (`votes/{uid}` rules), slot scoring (`rehearsal_scoring.dart`), a "Coming:" attendance list, and confirm/cancel/done statuses. That IS the when2meet-style coordinator the issue asked to evaluate — a heavy calendar/availability engine is rejected.

The one real gap found: `dailyEventReminder` scanned only `setlists`, so a confirmed rehearsal never produced a Telegram reminder. Fixed here:

- Confirmed rehearsals whose confirmed slot starts within 24h now notify band members (🥁 message with title + location).
- Scan extracted as `runDailyEventReminder({notify, now})` for testability; 3 emulator tests added (in-window rehearsal fires, out-of-window/collecting skipped, setlist path regression, broken confirmedSlotId ignored). telegram-db suite: 9 passing.

Needs `firebase deploy --only functions:dailyEventReminder` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)