### PR TITLE
feat(catalog): canonical browse + import (#59)

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -37,6 +37,7 @@ import '../screens/setlists/create_setlist_screen.dart';
 import '../screens/setlists/setlist_view_screen.dart';
 import '../screens/setlists/setlists_list_screen.dart';
 import '../screens/songs/add_song_screen.dart';
+import '../screens/songs/canonical_browse_screen.dart';
 import '../screens/songs/models/song_form_data.dart';
 import '../screens/songs/song_duplicates_screen.dart';
 import '../screens/songs/songs_list_screen.dart';
@@ -246,6 +247,11 @@ List<RouteBase> _buildAppRoutes() {
                   path: 'duplicates',
                   name: 'song-duplicates',
                   builder: (context, state) => const SongDuplicatesScreen(),
+                ),
+                GoRoute(
+                  path: 'catalog',
+                  name: 'canonical-browse',
+                  builder: (context, state) => const CanonicalBrowseScreen(),
                 ),
                 GoRoute(
                   path: 'add',

--- a/lib/screens/songs/canonical_browse_screen.dart
+++ b/lib/screens/songs/canonical_browse_screen.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/canonical_song.dart';
+import '../../providers/data/data_providers.dart';
+import '../../theme/mono_pulse_theme.dart';
+import '../../utils/canonical_import.dart';
+import '../../utils/snackbar.dart';
+import '../../widgets/empty_state.dart';
+import '../../widgets/standard_screen_scaffold.dart';
+
+/// Browse the shared canonical catalog and copy songs into the personal
+/// library (#59). Imported copies keep their [Song.canonicalSongId] link, so
+/// they materialize through the linked-song save path.
+class CanonicalBrowseScreen extends ConsumerStatefulWidget {
+  const CanonicalBrowseScreen({super.key});
+
+  @override
+  ConsumerState<CanonicalBrowseScreen> createState() =>
+      _CanonicalBrowseScreenState();
+}
+
+class _CanonicalBrowseScreenState extends ConsumerState<CanonicalBrowseScreen> {
+  final _searchCtrl = TextEditingController();
+  Timer? _debounce;
+  List<CanonicalSong> _results = const [];
+  bool _loading = false;
+  bool _searched = false;
+  final _importing = <String>{};
+  final _imported = <String>{};
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchCtrl.dispose();
+    super.dispose();
+  }
+
+  void _onQueryChanged(String q) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 300), () => _search(q));
+  }
+
+  Future<void> _search(String q) async {
+    final query = q.trim();
+    if (query.length < 2) {
+      setState(() {
+        _results = const [];
+        _searched = false;
+      });
+      return;
+    }
+    setState(() => _loading = true);
+    try {
+      final repo = ref.read(canonicalSongRepositoryProvider);
+      final results = await repo.search(query: query);
+      if (!mounted) return;
+      setState(() {
+        _results = results;
+        _loading = false;
+        _searched = true;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+      showAppSnackBar(context, 'Catalog search failed: $e');
+    }
+  }
+
+  Future<void> _import(CanonicalSong c) async {
+    setState(() => _importing.add(c.id));
+    try {
+      final song = canonicalToSong(c);
+      await ref.read(songRepositoryProvider).saveSong(song);
+      if (!mounted) return;
+      setState(() {
+        _importing.remove(c.id);
+        _imported.add(c.id);
+      });
+      showAppSnackBar(context, 'Added "${c.title}" to your songs');
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _importing.remove(c.id));
+      showAppSnackBar(context, 'Import failed: $e');
+    }
+  }
+
+  String _subtitle(CanonicalSong c) => [
+    if (c.artist.isNotEmpty) c.artist,
+    if (c.baseKey != null) c.baseKey!,
+    if (c.baseBpm != null) '${c.baseBpm} BPM',
+    if (c.baseSections.isNotEmpty) '${c.baseSections.length} sections',
+  ].join(' · ');
+
+  @override
+  Widget build(BuildContext context) {
+    return StandardScreenScaffold(
+      title: 'Song catalog',
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+            child: TextField(
+              controller: _searchCtrl,
+              onChanged: _onQueryChanged,
+              decoration: InputDecoration(
+                hintText: 'Search the catalog…',
+                prefixIcon: const Icon(Icons.search),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              textInputAction: TextInputAction.search,
+              onSubmitted: _search,
+            ),
+          ),
+          if (_loading) const LinearProgressIndicator(),
+          Expanded(child: _body()),
+        ],
+      ),
+    );
+  }
+
+  Widget _body() {
+    if (!_searched) {
+      return const EmptyState(
+        icon: Icons.library_music_outlined,
+        message: 'Browse the shared catalog',
+        hint:
+            'Search songs other FlowGroove users have added, and copy one '
+            'into your library — key, BPM and structure included.',
+      );
+    }
+    if (_results.isEmpty && !_loading) {
+      return const EmptyState(
+        icon: Icons.search_off,
+        message: 'No catalog matches',
+        hint: 'Try a different title — or add the song yourself and it '
+            'joins the catalog for everyone.',
+      );
+    }
+    return ListView.builder(
+      padding: const EdgeInsets.only(bottom: 96),
+      itemCount: _results.length,
+      itemBuilder: (context, i) {
+        final c = _results[i];
+        final busy = _importing.contains(c.id);
+        final done = _imported.contains(c.id);
+        return ListTile(
+          title: Text(c.displayTitle),
+          subtitle: Text(_subtitle(c)),
+          trailing: done
+              ? const Icon(Icons.check_circle,
+                  color: MonoPulseColors.accentOrange)
+              : busy
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : FilledButton.tonalIcon(
+                      onPressed: () => _import(c),
+                      icon: const Icon(Icons.add, size: 18),
+                      label: const Text('Add'),
+                    ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/songs/songs_list_screen.dart
+++ b/lib/screens/songs/songs_list_screen.dart
@@ -618,6 +618,11 @@ class _SongsListScreenState extends ConsumerState<SongsListScreen>
       showBackButton: false, // Hide back button for main tabs
       menuItems: [
         AppMenuItem(
+          icon: Icons.library_music_outlined,
+          label: 'Browse catalog',
+          onTap: () => context.pushNamed('canonical-browse'),
+        ),
+        AppMenuItem(
           icon: Icons.control_point_duplicate_outlined,
           label: 'Find duplicates',
           onTap: canExport

--- a/lib/utils/canonical_import.dart
+++ b/lib/utils/canonical_import.dart
@@ -1,0 +1,48 @@
+import 'package:uuid/uuid.dart';
+
+import '../models/canonical_song.dart';
+import '../models/section.dart';
+import '../models/song.dart';
+
+const _uuid = Uuid();
+
+/// Builds a personal-library [Song] seeded from a canonical catalog record
+/// (#59): base arrangement fields become the song's original AND "our"
+/// values, sections are cloned with fresh ids, and the copy stays linked via
+/// [Song.canonicalSongId].
+Song canonicalToSong(CanonicalSong c) {
+  final now = DateTime.now();
+  return Song(
+    id: _uuid.v4(),
+    title: c.title,
+    artist: c.artist,
+    album: c.album,
+    createdAt: now,
+    updatedAt: now,
+    originalKey: c.baseKey,
+    ourKey: c.baseKey,
+    originalBPM: c.baseBpm,
+    ourBPM: c.baseBpm,
+    accentBeats: c.baseAccentBeats,
+    regularBeats: c.baseRegularBeats,
+    beatModes: c.baseBeatModes,
+    links: c.baseLinks,
+    sections: [
+      for (final s in c.baseSections)
+        Section(
+          id: _uuid.v4(),
+          name: s.name,
+          notes: s.notes,
+          duration: s.duration,
+          colorValue: s.colorValue,
+          chordChart: s.chordChart,
+        ),
+    ],
+    spotifyId: c.spotifyId,
+    musicbrainzId: c.musicBrainzId,
+    isrc: c.isrc,
+    durationMs: c.durationMs,
+    canonicalSongId: c.id,
+    isFromMusicBrainz: c.musicBrainzId != null,
+  );
+}

--- a/test/screens/songs/canonical_browse_screen_test.dart
+++ b/test/screens/songs/canonical_browse_screen_test.dart
@@ -1,0 +1,71 @@
+import 'package:flowgroove/models/canonical_song.dart';
+import 'package:flowgroove/providers/data/data_providers.dart';
+import 'package:flowgroove/repositories/canonical_song_repository.dart';
+import 'package:flowgroove/screens/songs/canonical_browse_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeCanonicalRepo implements CanonicalSongRepository {
+  _FakeCanonicalRepo(this.songs);
+  final List<CanonicalSong> songs;
+  String? lastQuery;
+
+  @override
+  Future<List<CanonicalSong>> search({
+    required String query,
+    int limit = 20,
+  }) async {
+    lastQuery = query;
+    return songs;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+void main() {
+  final canonical = CanonicalSong(
+    id: 'c1',
+    title: 'Hey Joe',
+    artist: 'Jimi Hendrix',
+    baseKey: 'Em',
+    baseBpm: 82,
+  );
+
+  Future<_FakeCanonicalRepo> pump(WidgetTester tester) async {
+    final repo = _FakeCanonicalRepo([canonical]);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          canonicalSongRepositoryProvider.overrideWithValue(repo),
+        ],
+        child: const MaterialApp(home: CanonicalBrowseScreen()),
+      ),
+    );
+    await tester.pump();
+    return repo;
+  }
+
+  group('CanonicalBrowseScreen (#59)', () {
+    testWidgets('shows browse empty state before searching', (tester) async {
+      await pump(tester);
+      expect(find.text('Browse the shared catalog'), findsOneWidget);
+    });
+
+    testWidgets('search renders catalog rows with Add action', (tester) async {
+      final repo = await pump(tester);
+
+      await tester.enterText(find.byType(TextField), 'hey joe');
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      expect(repo.lastQuery, 'hey joe');
+      expect(find.text('Hey Joe'), findsOneWidget);
+      expect(find.textContaining('Jimi Hendrix'), findsOneWidget);
+      expect(find.textContaining('82 BPM'), findsOneWidget);
+      expect(find.text('Add'), findsOneWidget);
+    });
+  });
+}

--- a/test/utils/canonical_import_test.dart
+++ b/test/utils/canonical_import_test.dart
@@ -1,0 +1,54 @@
+import 'package:flowgroove/models/canonical_song.dart';
+import 'package:flowgroove/models/section.dart';
+import 'package:flowgroove/utils/canonical_import.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('canonicalToSong (#59)', () {
+    final canonical = CanonicalSong(
+      id: 'canon-1',
+      title: 'Hey Joe',
+      artist: 'Jimi Hendrix',
+      album: 'Are You Experienced',
+      baseKey: 'Em',
+      baseBpm: 82,
+      baseSections: [
+        Section(id: 'base-s1', name: 'Verse', duration: 4, chordChart: '[Em]x'),
+      ],
+      musicBrainzId: 'mb-123',
+      isrc: 'USAA00000001',
+    );
+
+    test('maps base arrangement into original AND our fields', () {
+      final song = canonicalToSong(canonical);
+
+      expect(song.title, 'Hey Joe');
+      expect(song.artist, 'Jimi Hendrix');
+      expect(song.album, 'Are You Experienced');
+      expect(song.originalKey, 'Em');
+      expect(song.ourKey, 'Em');
+      expect(song.originalBPM, 82);
+      expect(song.ourBPM, 82);
+      expect(song.canonicalSongId, 'canon-1');
+      expect(song.musicbrainzId, 'mb-123');
+      expect(song.isrc, 'USAA00000001');
+      expect(song.isFromMusicBrainz, isTrue);
+    });
+
+    test('clones sections with fresh ids', () {
+      final song = canonicalToSong(canonical);
+
+      expect(song.sections, hasLength(1));
+      expect(song.sections.single.name, 'Verse');
+      expect(song.sections.single.chordChart, '[Em]x');
+      expect(song.sections.single.id, isNot('base-s1'));
+    });
+
+    test('two imports produce distinct song and section ids', () {
+      final a = canonicalToSong(canonical);
+      final b = canonicalToSong(canonical);
+      expect(a.id, isNot(b.id));
+      expect(a.sections.single.id, isNot(b.sections.single.id));
+    });
+  });
+}


### PR DESCRIPTION
Closes #59.

- New **Song catalog** screen (Songs menu → "Browse catalog", route `canonical-browse`): debounced search over `canonical_songs` via the existing `FirestoreCanonicalSongRepository.search` prefix query; rows show title/artist/key/BPM/section count; **Add** copies the song into the personal library with progress/done states.
- `canonicalToSong` (lib/utils/canonical_import.dart): base arrangement → original AND "our" fields, sections cloned with fresh ids, `canonicalSongId` kept so `saveSong` takes the linked-song path (v2 shape + commits) — no hand-rolled Firestore writes.
- Add-to-band deliberately reuses the existing library-card action after import (ponytail: one import path).
- Tests: 3 mapping unit tests + 2 browse widget tests (fake repo). Full suite green (1964), analyze 0 errors.

Epic #58 note: with this merged, #58's remaining half (practice mode) was superseded (#60 closed → workbook pending teacher input), so #58 can close too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)