### PR TITLE
feat(lab): Song Lab data model + Firestore (#66)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,14 @@
 {
   "indexes": [
     {
+      "collectionGroup": "labEntries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "songs",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -215,6 +215,23 @@ service cloud.firestore {
           isValidLinkedSongCommit(request.auth.uid);
         allow update, delete: if false;
       }
+
+      // Song Lab (#66): journal entries, member tasks, version snapshots.
+      // Read = band member; write = non-demo editor/admin; delete also allowed
+      // to the entry author (fix your own note without admin rights).
+      match /{labCollection}/{labDocId} {
+        allow read: if labCollection in ['labEntries', 'tasks', 'versions'] &&
+          isAuthenticated() && isGlobalBandMember(bandId);
+        allow create, update: if labCollection in ['labEntries', 'tasks', 'versions'] &&
+          isAuthenticated() &&
+          isNotDemo(request.auth.uid) &&
+          isGlobalBandEditorOrAdmin(bandId);
+        allow delete: if labCollection in ['labEntries', 'tasks', 'versions'] &&
+          isAuthenticated() &&
+          isNotDemo(request.auth.uid) &&
+          (isGlobalBandEditorOrAdmin(bandId) ||
+            resource.data.authorId == request.auth.uid);
+      }
     }
 
     // ============================================================
@@ -301,6 +318,14 @@ service cloud.firestore {
             isNotDemo(userId) &&
             isValidLinkedSongCommit(userId);
           allow update, delete: if false;
+        }
+
+        // Song Lab (#66) on personal songs: owner-only.
+        match /{labCollection}/{labDocId} {
+          allow read: if labCollection in ['labEntries', 'tasks', 'versions'] &&
+            isAuthenticated() && (isOwner(userId) || isAdminOrOwner(userId));
+          allow create, update, delete: if labCollection in ['labEntries', 'tasks', 'versions'] &&
+            isAuthenticated() && isOwner(userId) && isNotDemo(userId);
         }
       }
 

--- a/functions/test/firestore-rules-song-lab.test.js
+++ b/functions/test/firestore-rules-song-lab.test.js
@@ -1,0 +1,143 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+} = require("@firebase/rules-unit-testing");
+
+const projectId = "repsync-app-lab-rules-test";
+const rules = fs.readFileSync(
+  path.resolve(__dirname, "../../firestore.rules"),
+  "utf8",
+);
+
+const entry = (author) => ({
+  id: "e1",
+  songId: "song-1",
+  type: "note",
+  body: "riff idea",
+  authorId: author,
+  visibility: "band",
+  createdAt: "2026-07-16T12:00:00.000",
+  updatedAt: "2026-07-16T12:00:00.000",
+  tags: [],
+  attachmentIds: [],
+});
+
+describe("Song Lab Firestore rules (#66)", function () {
+  this.timeout(20000);
+  let testEnv;
+
+  before(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId,
+      firestore: { rules },
+    });
+  });
+  after(async () => testEnv && testEnv.cleanup());
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await db.collection("users").doc("member").set({ uid: "member" });
+      await db.collection("users").doc("editor").set({ uid: "editor" });
+      await db.collection("users").doc("outsider").set({ uid: "outsider" });
+      await db.collection("bands").doc("band-1").set({
+        id: "band-1",
+        memberUids: ["member", "editor"],
+        editorUids: ["editor"],
+        adminUids: [],
+      });
+      await db
+        .collection("bands")
+        .doc("band-1")
+        .collection("songs")
+        .doc("song-1")
+        .set({ id: "song-1", title: "X" });
+      await db
+        .collection("users")
+        .doc("member")
+        .collection("songs")
+        .doc("song-p")
+        .set({ id: "song-p", title: "Y" });
+    });
+  });
+
+  const labDoc = (db, uid = "band-1") =>
+    db
+      .collection("bands")
+      .doc(uid)
+      .collection("songs")
+      .doc("song-1")
+      .collection("labEntries")
+      .doc("e1");
+
+  it("band member reads, editor writes, outsider denied", async () => {
+    const editor = testEnv.authenticatedContext("editor").firestore();
+    const member = testEnv.authenticatedContext("member").firestore();
+    const outsider = testEnv.authenticatedContext("outsider").firestore();
+
+    await assertSucceeds(labDoc(editor).set(entry("editor")));
+    await assertSucceeds(labDoc(member).get());
+    await assertFails(labDoc(member).set(entry("member"))); // member, not editor
+    await assertFails(labDoc(outsider).get());
+    await assertFails(labDoc(outsider).set(entry("outsider")));
+  });
+
+  it("author can delete own entry; plain member cannot delete others'", async () => {
+    const editor = testEnv.authenticatedContext("editor").firestore();
+    await assertSucceeds(labDoc(editor).set(entry("editor")));
+
+    const member = testEnv.authenticatedContext("member").firestore();
+    await assertFails(labDoc(member).delete());
+    await assertSucceeds(labDoc(editor).delete());
+  });
+
+  it("commits stay append-only despite the lab wildcard", async () => {
+    const editor = testEnv.authenticatedContext("editor").firestore();
+    const commit = editor
+      .collection("bands")
+      .doc("band-1")
+      .collection("songs")
+      .doc("song-1")
+      .collection("commits")
+      .doc("c1");
+    // update/delete on commits must still be denied for everyone.
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context
+        .firestore()
+        .collection("bands")
+        .doc("band-1")
+        .collection("songs")
+        .doc("song-1")
+        .collection("commits")
+        .doc("c1")
+        .set({ id: "c1" });
+    });
+    await assertFails(commit.update({ id: "c2" }));
+    await assertFails(commit.delete());
+  });
+
+  it("personal song lab is owner-only", async () => {
+    const owner = testEnv.authenticatedContext("member").firestore();
+    const stranger = testEnv.authenticatedContext("editor").firestore();
+    const doc = (db) =>
+      db
+        .collection("users")
+        .doc("member")
+        .collection("songs")
+        .doc("song-p")
+        .collection("tasks")
+        .doc("t1");
+
+    await assertSucceeds(
+      doc(owner).set({ id: "t1", songId: "song-p", title: "practice" }),
+    );
+    await assertFails(doc(stranger).get());
+    await assertFails(
+      doc(stranger).set({ id: "t1", songId: "song-p", title: "practice" }),
+    );
+  });
+});

--- a/lib/models/song_lab.dart
+++ b/lib/models/song_lab.dart
@@ -1,0 +1,297 @@
+/// Song Lab (#65/#66): the per-song journal — typed entries, member tasks and
+/// version snapshots stored as subcollections under a song document
+/// (`users/{uid}/songs/{id}/…` or `bands/{bandId}/songs/{id}/…`):
+/// `labEntries`, `tasks`, `versions`.
+///
+/// Conventions match the rest of the models: manual toJson/fromJson,
+/// timestamps as local ISO-8601 strings, enums stored by `.name`.
+library;
+
+/// Timeline entry types. The UI quick-adds only note/decision/experiment/
+/// problem (v1); the rest exist so other features can append typed entries.
+enum LabEntryType {
+  note,
+  idea,
+  decision,
+  experiment,
+  problem,
+  task,
+  rehearsalNote,
+  recording,
+  versionChange,
+  reference;
+
+  static LabEntryType parse(String? v) => LabEntryType.values.firstWhere(
+    (e) => e.name == v,
+    orElse: () => LabEntryType.note,
+  );
+}
+
+/// Per-type lifecycle, one flat enum (ponytail: statuses are strings in
+/// Firestore anyway — decision: active/superseded; experiment:
+/// planned/tried/accepted/rejected).
+enum SongTaskStatus {
+  todo,
+  doing,
+  done,
+  blocked,
+  skipped;
+
+  static SongTaskStatus parse(String? v) => SongTaskStatus.values.firstWhere(
+    (e) => e.name == v,
+    orElse: () => SongTaskStatus.todo,
+  );
+}
+
+DateTime _parseDate(dynamic v) =>
+    v is String ? (DateTime.tryParse(v) ?? DateTime.now()) : DateTime.now();
+DateTime? _parseDateOrNull(dynamic v) =>
+    v is String ? DateTime.tryParse(v) : null;
+
+class SongLabEntry {
+  SongLabEntry({
+    required this.id,
+    required this.songId,
+    required this.type,
+    required this.authorId,
+    required this.createdAt,
+    required this.updatedAt,
+    this.bandId,
+    this.title,
+    this.body,
+    this.sectionId,
+    this.versionId,
+    this.status,
+    this.tags = const [],
+    this.visibility = 'band',
+    this.attachmentIds = const [],
+  });
+
+  factory SongLabEntry.fromJson(Map<String, dynamic> json) => SongLabEntry(
+    id: json['id'] as String? ?? '',
+    songId: json['songId'] as String? ?? '',
+    bandId: json['bandId'] as String?,
+    type: LabEntryType.parse(json['type'] as String?),
+    title: json['title'] as String?,
+    body: json['body'] as String?,
+    sectionId: json['sectionId'] as String?,
+    versionId: json['versionId'] as String?,
+    status: json['status'] as String?,
+    tags: (json['tags'] as List?)?.whereType<String>().toList() ?? const [],
+    authorId: json['authorId'] as String? ?? '',
+    visibility: json['visibility'] as String? ?? 'band',
+    createdAt: _parseDate(json['createdAt']),
+    updatedAt: _parseDate(json['updatedAt']),
+    attachmentIds:
+        (json['attachmentIds'] as List?)?.whereType<String>().toList() ??
+        const [],
+  );
+
+  final String id;
+  final String songId;
+
+  /// Duplicated on band-song entries for band-wide collection-group queries.
+  final String? bandId;
+  final LabEntryType type;
+  final String? title;
+  final String? body;
+
+  /// Optional binding to a song [Section.id].
+  final String? sectionId;
+
+  /// Set on `versionChange` entries.
+  final String? versionId;
+
+  /// Type-specific lifecycle: decision `active`/`superseded`; experiment
+  /// `planned`/`tried`/`accepted`/`rejected`. Null for plain notes.
+  final String? status;
+  final List<String> tags;
+  final String authorId;
+
+  /// 'private' | 'band'.
+  final String visibility;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final List<String> attachmentIds;
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'songId': songId,
+    if (bandId != null) 'bandId': bandId,
+    'type': type.name,
+    if (title != null) 'title': title,
+    if (body != null) 'body': body,
+    if (sectionId != null) 'sectionId': sectionId,
+    if (versionId != null) 'versionId': versionId,
+    if (status != null) 'status': status,
+    'tags': tags,
+    'authorId': authorId,
+    'visibility': visibility,
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+    'attachmentIds': attachmentIds,
+  };
+
+  SongLabEntry copyWith({String? title, String? body, String? status}) =>
+      SongLabEntry(
+        id: id,
+        songId: songId,
+        bandId: bandId,
+        type: type,
+        title: title ?? this.title,
+        body: body ?? this.body,
+        sectionId: sectionId,
+        versionId: versionId,
+        status: status ?? this.status,
+        tags: tags,
+        authorId: authorId,
+        visibility: visibility,
+        createdAt: createdAt,
+        updatedAt: DateTime.now(),
+        attachmentIds: attachmentIds,
+      );
+}
+
+class SongTask {
+  SongTask({
+    required this.id,
+    required this.songId,
+    required this.title,
+    required this.createdAt,
+    required this.updatedAt,
+    this.bandId,
+    this.assignedToUserId,
+    this.status = SongTaskStatus.todo,
+    this.sectionId,
+    this.dueAt,
+    this.priority = 0,
+  });
+
+  factory SongTask.fromJson(Map<String, dynamic> json) => SongTask(
+    id: json['id'] as String? ?? '',
+    songId: json['songId'] as String? ?? '',
+    bandId: json['bandId'] as String?,
+    assignedToUserId: json['assignedToUserId'] as String?,
+    title: json['title'] as String? ?? '',
+    status: SongTaskStatus.parse(json['status'] as String?),
+    sectionId: json['sectionId'] as String?,
+    dueAt: _parseDateOrNull(json['dueAt']),
+    priority: (json['priority'] as num?)?.toInt() ?? 0,
+    createdAt: _parseDate(json['createdAt']),
+    updatedAt: _parseDate(json['updatedAt']),
+  );
+
+  final String id;
+  final String songId;
+  final String? bandId;
+  final String? assignedToUserId;
+  final String title;
+  final SongTaskStatus status;
+  final String? sectionId;
+  final DateTime? dueAt;
+  final int priority;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  bool get isOpen =>
+      status == SongTaskStatus.todo ||
+      status == SongTaskStatus.doing ||
+      status == SongTaskStatus.blocked;
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'songId': songId,
+    if (bandId != null) 'bandId': bandId,
+    if (assignedToUserId != null) 'assignedToUserId': assignedToUserId,
+    'title': title,
+    'status': status.name,
+    if (sectionId != null) 'sectionId': sectionId,
+    if (dueAt != null) 'dueAt': dueAt!.toIso8601String(),
+    'priority': priority,
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+  };
+
+  SongTask copyWith({
+    String? title,
+    SongTaskStatus? status,
+    String? assignedToUserId,
+    DateTime? dueAt,
+  }) => SongTask(
+    id: id,
+    songId: songId,
+    bandId: bandId,
+    assignedToUserId: assignedToUserId ?? this.assignedToUserId,
+    title: title ?? this.title,
+    status: status ?? this.status,
+    sectionId: sectionId,
+    dueAt: dueAt ?? this.dueAt,
+    priority: priority,
+    createdAt: createdAt,
+    updatedAt: DateTime.now(),
+  );
+}
+
+class SongVersion {
+  SongVersion({
+    required this.id,
+    required this.songId,
+    required this.name,
+    required this.createdAt,
+    this.bandId,
+    this.status = 'archived',
+    this.bpm,
+    this.key,
+    this.structureSnapshot,
+    this.lyricsSnapshot,
+    this.notes,
+  });
+
+  factory SongVersion.fromJson(Map<String, dynamic> json) => SongVersion(
+    id: json['id'] as String? ?? '',
+    songId: json['songId'] as String? ?? '',
+    bandId: json['bandId'] as String?,
+    name: json['name'] as String? ?? '',
+    status: json['status'] as String? ?? 'archived',
+    bpm: (json['bpm'] as num?)?.toInt(),
+    key: json['key'] as String?,
+    structureSnapshot: json['structureSnapshot'] as String?,
+    lyricsSnapshot: json['lyricsSnapshot'] as String?,
+    notes: json['notes'] as String?,
+    createdAt: _parseDate(json['createdAt']),
+  );
+
+  final String id;
+  final String songId;
+  final String? bandId;
+  final String name;
+
+  /// 'current' | 'archived' — exactly one version should be current.
+  final String status;
+  final int? bpm;
+  final String? key;
+
+  /// Song-map summary at snapshot time (section names/durations).
+  final String? structureSnapshot;
+
+  /// Full ChordPro document at snapshot time ([songToChordPro]).
+  final String? lyricsSnapshot;
+  final String? notes;
+  final DateTime createdAt;
+
+  bool get isCurrent => status == 'current';
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'songId': songId,
+    if (bandId != null) 'bandId': bandId,
+    'name': name,
+    'status': status,
+    if (bpm != null) 'bpm': bpm,
+    if (key != null) 'key': key,
+    if (structureSnapshot != null) 'structureSnapshot': structureSnapshot,
+    if (lyricsSnapshot != null) 'lyricsSnapshot': lyricsSnapshot,
+    if (notes != null) 'notes': notes,
+    'createdAt': createdAt.toIso8601String(),
+  };
+}

--- a/lib/providers/data/data_providers.dart
+++ b/lib/providers/data/data_providers.dart
@@ -7,6 +7,7 @@ import '../../models/canonical_song.dart';
 import '../../models/rehearsal.dart';
 import '../../models/setlist.dart';
 import '../../models/song.dart';
+import '../../models/song_lab.dart';
 import '../../repositories/repositories.dart';
 import '../../services/band_function_service.dart';
 import '../../services/canonical_song_function_service.dart';
@@ -37,6 +38,37 @@ final songRepositoryProvider = Provider<SongRepository>((ref) {
     auth: ref.watch(firebaseAuthProvider),
   );
 });
+
+/// Song Lab (#66): repository + per-song streams. Family key: (songId, bandId
+/// — null for personal songs).
+final labRepositoryProvider = Provider<FirestoreLabRepository>((ref) {
+  return FirestoreLabRepository(
+    firestore: ref.watch(firebaseFirestoreProvider),
+    auth: ref.watch(firebaseAuthProvider),
+  );
+});
+
+final labEntriesProvider = StreamProvider.autoDispose
+    .family<List<SongLabEntry>, (String, String?)>((ref, key) {
+      final (songId, bandId) = key;
+      return ref
+          .watch(labRepositoryProvider)
+          .watchEntries(songId, bandId: bandId);
+    });
+
+final labTasksProvider = StreamProvider.autoDispose
+    .family<List<SongTask>, (String, String?)>((ref, key) {
+      final (songId, bandId) = key;
+      return ref.watch(labRepositoryProvider).watchTasks(songId, bandId: bandId);
+    });
+
+final labVersionsProvider = StreamProvider.autoDispose
+    .family<List<SongVersion>, (String, String?)>((ref, key) {
+      final (songId, bandId) = key;
+      return ref
+          .watch(labRepositoryProvider)
+          .watchVersions(songId, bandId: bandId);
+    });
 
 /// Provider for the BandRepository.
 ///

--- a/lib/repositories/firestore_lab_repository.dart
+++ b/lib/repositories/firestore_lab_repository.dart
@@ -1,0 +1,122 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/song_lab.dart';
+
+/// Firestore access for Song Lab subcollections (#66) under a song doc:
+/// `labEntries`, `tasks`, `versions` — for personal songs
+/// (`users/{uid}/songs/{songId}`) and band songs
+/// (`bands/{bandId}/songs/{songId}`), selected by [bandId].
+///
+/// ponytail: single concrete class, no interface — one implementation exists.
+class FirestoreLabRepository {
+  FirestoreLabRepository({FirebaseFirestore? firestore, FirebaseAuth? auth})
+    : _firestore = firestore ?? FirebaseFirestore.instance,
+      _auth = auth ?? FirebaseAuth.instance;
+
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+
+  String get _uid {
+    final user = _auth.currentUser;
+    if (user == null) {
+      throw StateError('Not signed in');
+    }
+    return user.uid;
+  }
+
+  DocumentReference<Map<String, dynamic>> _songDoc(
+    String songId, {
+    String? bandId,
+  }) => bandId != null
+      ? _firestore.collection('bands').doc(bandId).collection('songs').doc(songId)
+      : _firestore.collection('users').doc(_uid).collection('songs').doc(songId);
+
+  // ---- Entries ----
+
+  Stream<List<SongLabEntry>> watchEntries(String songId, {String? bandId}) =>
+      _songDoc(songId, bandId: bandId)
+          .collection('labEntries')
+          .orderBy('createdAt', descending: true)
+          .snapshots()
+          .map(
+            (s) => s.docs.map((d) => SongLabEntry.fromJson(d.data())).toList(),
+          );
+
+  Future<void> saveEntry(SongLabEntry entry, {String? bandId}) =>
+      _songDoc(entry.songId, bandId: bandId)
+          .collection('labEntries')
+          .doc(entry.id)
+          .set(entry.toJson());
+
+  Future<void> deleteEntry(
+    String songId,
+    String entryId, {
+    String? bandId,
+  }) => _songDoc(songId, bandId: bandId)
+      .collection('labEntries')
+      .doc(entryId)
+      .delete();
+
+  // ---- Tasks ----
+
+  Stream<List<SongTask>> watchTasks(String songId, {String? bandId}) =>
+      _songDoc(songId, bandId: bandId)
+          .collection('tasks')
+          .orderBy('createdAt', descending: true)
+          .snapshots()
+          .map((s) => s.docs.map((d) => SongTask.fromJson(d.data())).toList());
+
+  Future<void> saveTask(SongTask task, {String? bandId}) =>
+      _songDoc(task.songId, bandId: bandId)
+          .collection('tasks')
+          .doc(task.id)
+          .set(task.toJson());
+
+  Future<void> deleteTask(String songId, String taskId, {String? bandId}) =>
+      _songDoc(songId, bandId: bandId).collection('tasks').doc(taskId).delete();
+
+  /// Open tasks for one song, one-shot (the "before rehearsal" counter, #68).
+  Future<int> openTaskCount(String songId, {String? bandId}) async {
+    final snap = await _songDoc(songId, bandId: bandId)
+        .collection('tasks')
+        .where('status', whereIn: ['todo', 'doing', 'blocked'])
+        .count()
+        .get();
+    return snap.count ?? 0;
+  }
+
+  // ---- Versions ----
+
+  Stream<List<SongVersion>> watchVersions(String songId, {String? bandId}) =>
+      _songDoc(songId, bandId: bandId)
+          .collection('versions')
+          .orderBy('createdAt', descending: true)
+          .snapshots()
+          .map(
+            (s) => s.docs.map((d) => SongVersion.fromJson(d.data())).toList(),
+          );
+
+  Future<void> saveVersion(SongVersion version, {String? bandId}) =>
+      _songDoc(version.songId, bandId: bandId)
+          .collection('versions')
+          .doc(version.id)
+          .set(version.toJson());
+
+  /// Marks [versionId] current and archives every other version in one batch.
+  Future<void> setCurrentVersion(
+    String songId,
+    String versionId, {
+    String? bandId,
+  }) async {
+    final col = _songDoc(songId, bandId: bandId).collection('versions');
+    final snap = await col.get();
+    final batch = _firestore.batch();
+    for (final d in snap.docs) {
+      batch.update(d.reference, {
+        'status': d.id == versionId ? 'current' : 'archived',
+      });
+    }
+    await batch.commit();
+  }
+}

--- a/lib/repositories/repositories.dart
+++ b/lib/repositories/repositories.dart
@@ -8,6 +8,7 @@ export 'band_repository.dart';
 export 'canonical_song_repository.dart';
 export 'firestore_band_repository.dart';
 export 'firestore_canonical_song_repository.dart';
+export 'firestore_lab_repository.dart';
 export 'firestore_rehearsal_repository.dart';
 export 'firestore_setlist_repository.dart';
 export 'firestore_song_repository.dart';

--- a/test/models/song_lab_test.dart
+++ b/test/models/song_lab_test.dart
@@ -1,0 +1,77 @@
+import 'package:flowgroove/models/song_lab.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Song Lab models (#66)', () {
+    test('SongLabEntry round-trips through JSON', () {
+      final entry = SongLabEntry(
+        id: 'e1',
+        songId: 's1',
+        bandId: 'b1',
+        type: LabEntryType.decision,
+        title: 'Half-time chorus',
+        body: 'We play the last chorus half-time.',
+        sectionId: 'sec-1',
+        status: 'active',
+        tags: const ['arrangement'],
+        authorId: 'u1',
+        visibility: 'band',
+        createdAt: DateTime(2026, 7, 16, 12),
+        updatedAt: DateTime(2026, 7, 16, 12),
+        attachmentIds: const ['a1'],
+      );
+
+      final back = SongLabEntry.fromJson(entry.toJson());
+      expect(back.id, 'e1');
+      expect(back.type, LabEntryType.decision);
+      expect(back.status, 'active');
+      expect(back.sectionId, 'sec-1');
+      expect(back.tags, ['arrangement']);
+      expect(back.attachmentIds, ['a1']);
+      expect(back.createdAt, DateTime(2026, 7, 16, 12));
+    });
+
+    test('unknown entry type parses to note, unknown status to todo', () {
+      expect(LabEntryType.parse('hologram'), LabEntryType.note);
+      expect(SongTaskStatus.parse('later'), SongTaskStatus.todo);
+    });
+
+    test('SongTask round-trips and knows openness', () {
+      final task = SongTask(
+        id: 't1',
+        songId: 's1',
+        title: 'Learn the solo',
+        assignedToUserId: 'u2',
+        status: SongTaskStatus.doing,
+        dueAt: DateTime(2026, 8, 1),
+        priority: 1,
+        createdAt: DateTime(2026, 7, 16),
+        updatedAt: DateTime(2026, 7, 16),
+      );
+      final back = SongTask.fromJson(task.toJson());
+      expect(back.status, SongTaskStatus.doing);
+      expect(back.dueAt, DateTime(2026, 8, 1));
+      expect(back.isOpen, isTrue);
+      expect(back.copyWith(status: SongTaskStatus.done).isOpen, isFalse);
+    });
+
+    test('SongVersion round-trips with snapshots and current flag', () {
+      final v = SongVersion(
+        id: 'v1',
+        songId: 's1',
+        name: 'v0.3 Acoustic',
+        status: 'current',
+        bpm: 96,
+        key: 'Am',
+        structureSnapshot: 'Verse ×2 · Chorus',
+        lyricsSnapshot: '{title: X}\n[Am]la',
+        notes: 'slower intro',
+        createdAt: DateTime(2026, 7, 16),
+      );
+      final back = SongVersion.fromJson(v.toJson());
+      expect(back.isCurrent, isTrue);
+      expect(back.bpm, 96);
+      expect(back.lyricsSnapshot, contains('[Am]la'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #66. Foundation PR for the Song Lab epic #65 (timeline UI #67, tasks #68, versions #70, recordings #69 build on this).

- **Models** (`lib/models/song_lab.dart`): `SongLabEntry` (10 typed entry kinds per spec, section binding, band visibility, attachments), `SongTask` (assignee/status/due/priority + `isOpen`), `SongVersion` (bpm/key/structure/ChordPro lyrics snapshots, single `current`). Conventions: manual JSON, `.name` enums, ISO timestamps.
- **Repository + providers**: `FirestoreLabRepository` over `users/{uid}/songs/{id}/…` and `bands/{bandId}/songs/{id}/…` subcollections (`labEntries|tasks|versions`); `StreamProvider.autoDispose.family` keyed by (songId, bandId).
- **Rules**: band songs — member read, editor+ write, author-or-editor delete; personal songs — owner-only. Written as a guarded wildcard (`labCollection in [...]`) so `commits/` keeps its append-only block — covered by a dedicated rules test. **Deployed.**
- **Index**: `labEntries` type+createdAt (filtered timeline). **Deployed.**
- Offline-first comes from the already-enabled Firestore persistence.
- Tests: 4 Dart model round-trips; 4 rules tests (rules suite 13 passing under the emulator). Full Flutter suite green (1970), analyze 0 errors.

song.notes migration happens lazily on first Lab open (ships with #67's UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)