### PR TITLE
feat(lab): Song Lab timeline UI (#67)

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -38,6 +38,7 @@ import '../screens/setlists/setlist_view_screen.dart';
 import '../screens/setlists/setlists_list_screen.dart';
 import '../screens/songs/add_song_screen.dart';
 import '../screens/songs/canonical_browse_screen.dart';
+import '../screens/songs/song_lab_screen.dart';
 import '../screens/songs/models/song_form_data.dart';
 import '../screens/songs/song_duplicates_screen.dart';
 import '../screens/songs/songs_list_screen.dart';
@@ -263,6 +264,17 @@ List<RouteBase> _buildAppRoutes() {
                       initialFormData: state.extra is SongFormData
                           ? state.extra! as SongFormData
                           : null,
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: ':id/lab',
+                  name: 'song-lab',
+                  builder: (context, state) {
+                    final extra = state.extra! as Map;
+                    return SongLabScreen(
+                      song: extra['song'] as Song,
+                      bandId: extra['bandId'] as String?,
                     );
                   },
                 ),

--- a/lib/screens/songs/song_lab_screen.dart
+++ b/lib/screens/songs/song_lab_screen.dart
@@ -1,0 +1,445 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../models/song.dart';
+import '../../models/song_lab.dart';
+import '../../providers/auth/auth_provider.dart';
+import '../../providers/data/data_providers.dart';
+import '../../services/analytics_service.dart';
+import '../../theme/mono_pulse_theme.dart';
+import '../../utils/snackbar.dart';
+import '../../widgets/app_filter_chip.dart';
+import '../../widgets/empty_state.dart';
+import '../../widgets/standard_screen_scaffold.dart';
+
+/// Song Lab timeline (#67): a reverse-chronological journal of typed entries
+/// for one song — the history of "our version" (notes, decisions,
+/// experiments, problems). Quick-add covers 4 types; the model carries more.
+class SongLabScreen extends ConsumerStatefulWidget {
+  const SongLabScreen({required this.song, this.bandId, super.key});
+
+  final Song song;
+  final String? bandId;
+
+  @override
+  ConsumerState<SongLabScreen> createState() => _SongLabScreenState();
+}
+
+class _SongLabScreenState extends ConsumerState<SongLabScreen> {
+  static const _uuid = Uuid();
+
+  /// null = all types.
+  LabEntryType? _typeFilter;
+  bool _migrated = false;
+
+  (String, String?) get _key => (widget.song.id, widget.bandId);
+
+  static const _quickTypes = [
+    LabEntryType.note,
+    LabEntryType.decision,
+    LabEntryType.experiment,
+    LabEntryType.problem,
+  ];
+
+  static const _typeIcons = <LabEntryType, IconData>{
+    LabEntryType.note: Icons.sticky_note_2_outlined,
+    LabEntryType.idea: Icons.lightbulb_outline,
+    LabEntryType.decision: Icons.gavel_outlined,
+    LabEntryType.experiment: Icons.science_outlined,
+    LabEntryType.problem: Icons.report_problem_outlined,
+    LabEntryType.task: Icons.check_circle_outline,
+    LabEntryType.rehearsalNote: Icons.event_note_outlined,
+    LabEntryType.recording: Icons.mic_outlined,
+    LabEntryType.versionChange: Icons.history,
+    LabEntryType.reference: Icons.link,
+  };
+
+  static String _typeLabel(LabEntryType t) => switch (t) {
+    LabEntryType.rehearsalNote => 'Rehearsal note',
+    LabEntryType.versionChange => 'Version',
+    _ => t.name[0].toUpperCase() + t.name.substring(1),
+  };
+
+  /// One-time lazy migration (#66): the song's free-text notes become the
+  /// first timeline entry, so the Lab never opens empty on an annotated song.
+  Future<void> _migrateNotesIfNeeded(List<SongLabEntry> entries) async {
+    if (_migrated || entries.isNotEmpty) return;
+    final notes = widget.song.notes;
+    if (notes == null || notes.trim().isEmpty) return;
+    _migrated = true;
+    final uid = ref.read(firebaseAuthProvider).currentUser?.uid ?? '';
+    final now = DateTime.now();
+    await ref
+        .read(labRepositoryProvider)
+        .saveEntry(
+          SongLabEntry(
+            id: _uuid.v4(),
+            songId: widget.song.id,
+            bandId: widget.bandId,
+            type: LabEntryType.note,
+            title: 'Imported notes',
+            body: notes,
+            authorId: uid,
+            createdAt: now,
+            updatedAt: now,
+          ),
+          bandId: widget.bandId,
+        );
+  }
+
+  Future<void> _compose(LabEntryType type, {SongLabEntry? existing}) async {
+    final result = await showModalBottomSheet<_ComposeResult>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => _ComposeEntrySheet(
+        type: existing?.type ?? type,
+        song: widget.song,
+        existing: existing,
+      ),
+    );
+    if (result == null || !mounted) return;
+
+    final repo = ref.read(labRepositoryProvider);
+    if (existing != null) {
+      await repo.saveEntry(
+        existing.copyWith(title: result.title, body: result.body),
+        bandId: widget.bandId,
+      );
+      return;
+    }
+    final uid = ref.read(firebaseAuthProvider).currentUser?.uid ?? '';
+    final now = DateTime.now();
+    await repo.saveEntry(
+      SongLabEntry(
+        id: _uuid.v4(),
+        songId: widget.song.id,
+        bandId: widget.bandId,
+        type: type,
+        title: result.title,
+        body: result.body,
+        sectionId: result.sectionId,
+        status: switch (type) {
+          LabEntryType.decision => 'active',
+          LabEntryType.experiment => 'planned',
+          _ => null,
+        },
+        authorId: uid,
+        createdAt: now,
+        updatedAt: now,
+      ),
+      bandId: widget.bandId,
+    );
+    unawaited(AnalyticsService.logLabEntryAdded(type: type.name));
+  }
+
+  Future<void> _delete(SongLabEntry entry) async {
+    final repo = ref.read(labRepositoryProvider);
+    await repo.deleteEntry(widget.song.id, entry.id, bandId: widget.bandId);
+    if (!mounted) return;
+    showAppSnackBar(
+      context,
+      'Entry deleted',
+      actionLabel: 'Undo',
+      onAction: () => repo.saveEntry(entry, bandId: widget.bandId),
+    );
+  }
+
+  Future<void> _setStatus(SongLabEntry entry, String status) => ref
+      .read(labRepositoryProvider)
+      .saveEntry(entry.copyWith(status: status), bandId: widget.bandId);
+
+  @override
+  Widget build(BuildContext context) {
+    final entriesAsync = ref.watch(labEntriesProvider(_key));
+
+    return StandardScreenScaffold(
+      title: 'Lab — ${widget.song.title}',
+      body: entriesAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Failed to load Lab: $e')),
+        data: (entries) {
+          _migrateNotesIfNeeded(entries);
+          final visible = _typeFilter == null
+              ? entries
+              : entries.where((e) => e.type == _typeFilter).toList();
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _quickAddRow(),
+              if (entries.isNotEmpty) _filterRow(),
+              Expanded(
+                child: visible.isEmpty
+                    ? EmptyState(
+                        icon: Icons.science_outlined,
+                        message: entries.isEmpty
+                            ? 'The story of this song starts here'
+                            : 'Nothing of this type yet',
+                        hint: entries.isEmpty
+                            ? 'Capture ideas, decisions ("why we play it '
+                                  'this way"), experiments and problems — '
+                                  'so the band never loses the context.'
+                            : null,
+                      )
+                    : ListView.builder(
+                        padding: const EdgeInsets.only(bottom: 96),
+                        itemCount: visible.length,
+                        itemBuilder: (context, i) => _entryCard(visible[i]),
+                      ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _quickAddRow() => Padding(
+    padding: const EdgeInsets.fromLTRB(
+      MonoPulseSpacing.lg,
+      MonoPulseSpacing.md,
+      MonoPulseSpacing.lg,
+      0,
+    ),
+    child: Wrap(
+      spacing: MonoPulseSpacing.sm,
+      children: [
+        for (final t in _quickTypes)
+          ActionChip(
+            avatar: Icon(_typeIcons[t], size: 18),
+            label: Text('+ ${_typeLabel(t)}'),
+            onPressed: () => _compose(t),
+          ),
+      ],
+    ),
+  );
+
+  Widget _filterRow() => Padding(
+    padding: const EdgeInsets.symmetric(
+      horizontal: MonoPulseSpacing.lg,
+      vertical: MonoPulseSpacing.sm,
+    ),
+    child: SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          AppFilterChip(
+            label: 'All',
+            selected: _typeFilter == null,
+            onSelected: (_) => setState(() => _typeFilter = null),
+          ),
+          const SizedBox(width: MonoPulseSpacing.sm),
+          for (final t in _quickTypes) ...[
+            AppFilterChip(
+              label: _typeLabel(t),
+              selected: _typeFilter == t,
+              onSelected: (sel) =>
+                  setState(() => _typeFilter = sel ? t : null),
+            ),
+            const SizedBox(width: MonoPulseSpacing.sm),
+          ],
+        ],
+      ),
+    ),
+  );
+
+  String _sectionName(String? sectionId) {
+    if (sectionId == null) return '';
+    final match = widget.song.sections.where((s) => s.id == sectionId);
+    return match.isEmpty ? '' : match.first.name;
+  }
+
+  Widget _entryCard(SongLabEntry e) {
+    final section = _sectionName(e.sectionId);
+    final superseded = e.status == 'superseded';
+    return Card(
+      margin: const EdgeInsets.symmetric(
+        horizontal: MonoPulseSpacing.lg,
+        vertical: MonoPulseSpacing.xs,
+      ),
+      child: ListTile(
+        leading: Icon(
+          _typeIcons[e.type],
+          color: superseded
+              ? MonoPulseColors.textSecondary
+              : MonoPulseColors.accentOrange,
+        ),
+        title: Text(
+          e.title?.isNotEmpty == true ? e.title! : _typeLabel(e.type),
+          style: superseded
+              ? const TextStyle(
+                  decoration: TextDecoration.lineThrough,
+                  color: MonoPulseColors.textSecondary,
+                )
+              : null,
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (e.body?.isNotEmpty == true)
+              Text(e.body!, maxLines: 4, overflow: TextOverflow.ellipsis),
+            Text(
+              [
+                _typeLabel(e.type),
+                if (e.status != null) e.status!,
+                if (section.isNotEmpty) section,
+                '${e.createdAt.day}/${e.createdAt.month}/${e.createdAt.year}',
+              ].join(' · '),
+              style: MonoPulseTypography.bodySmall.copyWith(
+                color: MonoPulseColors.textSecondary,
+              ),
+            ),
+          ],
+        ),
+        trailing: PopupMenuButton<String>(
+          onSelected: (v) => switch (v) {
+            'edit' => _compose(e.type, existing: e),
+            'supersede' => _setStatus(e, 'superseded'),
+            'accepted' || 'rejected' || 'tried' => _setStatus(e, v),
+            'delete' => _delete(e),
+            _ => null,
+          },
+          itemBuilder: (_) => [
+            const PopupMenuItem(value: 'edit', child: Text('Edit')),
+            if (e.type == LabEntryType.decision && e.status == 'active')
+              const PopupMenuItem(
+                value: 'supersede',
+                child: Text('Mark superseded'),
+              ),
+            if (e.type == LabEntryType.experiment) ...[
+              const PopupMenuItem(value: 'tried', child: Text('Tried it')),
+              const PopupMenuItem(value: 'accepted', child: Text('Accepted')),
+              const PopupMenuItem(value: 'rejected', child: Text('Rejected')),
+            ],
+            const PopupMenuItem(value: 'delete', child: Text('Delete')),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ComposeResult {
+  _ComposeResult(this.title, this.body, this.sectionId);
+  final String? title;
+  final String? body;
+  final String? sectionId;
+}
+
+class _ComposeEntrySheet extends StatefulWidget {
+  const _ComposeEntrySheet({
+    required this.type,
+    required this.song,
+    this.existing,
+  });
+
+  final LabEntryType type;
+  final Song song;
+  final SongLabEntry? existing;
+
+  @override
+  State<_ComposeEntrySheet> createState() => _ComposeEntrySheetState();
+}
+
+class _ComposeEntrySheetState extends State<_ComposeEntrySheet> {
+  late final _title = TextEditingController(text: widget.existing?.title);
+  late final _body = TextEditingController(text: widget.existing?.body);
+  String? _sectionId;
+
+  @override
+  void initState() {
+    super.initState();
+    _sectionId = widget.existing?.sectionId;
+  }
+
+  @override
+  void dispose() {
+    _title.dispose();
+    _body.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.existing == null
+                  ? 'New ${widget.type.name}'
+                  : 'Edit ${widget.type.name}',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            TextField(
+              controller: _title,
+              decoration: const InputDecoration(
+                labelText: 'Title (optional)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            TextField(
+              controller: _body,
+              maxLines: 5,
+              minLines: 2,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'What happened?',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            if (widget.song.sections.isNotEmpty &&
+                widget.existing == null) ...[
+              const SizedBox(height: MonoPulseSpacing.md),
+              DropdownButtonFormField<String?>(
+                initialValue: _sectionId,
+                decoration: const InputDecoration(
+                  labelText: 'Section (optional)',
+                  border: OutlineInputBorder(),
+                ),
+                items: [
+                  const DropdownMenuItem(value: null, child: Text('—')),
+                  for (final s in widget.song.sections)
+                    DropdownMenuItem(value: s.id, child: Text(s.name)),
+                ],
+                onChanged: (v) => setState(() => _sectionId = v),
+              ),
+            ],
+            const SizedBox(height: MonoPulseSpacing.lg),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Cancel'),
+                ),
+                const SizedBox(width: MonoPulseSpacing.sm),
+                ElevatedButton(
+                  onPressed: () => Navigator.pop(
+                    context,
+                    _ComposeResult(
+                      _title.text.trim().isEmpty ? null : _title.text.trim(),
+                      _body.text.trim().isEmpty ? null : _body.text.trim(),
+                      _sectionId,
+                    ),
+                  ),
+                  child: const Text('Save'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/analytics_events.dart
+++ b/lib/services/analytics_events.dart
@@ -66,6 +66,9 @@ class AnalyticsEvents {
   static const String csvExported = 'csv_exported';
   static const String spotifyLinked = 'spotify_linked';
 
+  // Song Lab (#67)
+  static const String labEntryAdded = 'lab_entry_added';
+
   // HEART framework (UX audit, 2026-07)
   static const String backUsed = 'back_used';
   static const String menuOpened = 'menu_opened';

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -944,6 +944,10 @@ class AnalyticsService {
     }
   }
 
+  /// E: a Song Lab entry was created (#67). [type] is the LabEntryType name.
+  static Future<void> logLabEntryAdded({required String type}) =>
+      _log(AnalyticsEvents.labEntryAdded, {'type': type});
+
   /// T: back navigation used — the in-app Back button ('ui') or a system
   /// back gesture/button intercepted by a `PopScope` ('system').
   static Future<void> logBackUsed({required String source}) =>

--- a/lib/widgets/unified_item/song_card_actions.dart
+++ b/lib/widgets/unified_item/song_card_actions.dart
@@ -121,6 +121,15 @@ mixin SongCardActions<T extends ConsumerStatefulWidget> on ConsumerState<T> {
               () => openPerformanceSheet(song),
             ),
           ('Open in Tuner', Icons.tune, () => openInTuner(song)),
+          (
+            'Song Lab',
+            Icons.science_outlined,
+            () => context.pushNamed(
+              'song-lab',
+              pathParameters: {'id': song.id},
+              extra: {'song': song, 'bandId': songActionsBandId},
+            ),
+          ),
           if (bands.isNotEmpty)
             (
               'Add to band…',

--- a/test/screens/songs/song_lab_screen_test.dart
+++ b/test/screens/songs/song_lab_screen_test.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+
+import 'package:flowgroove/models/section.dart';
+import 'package:flowgroove/models/song.dart';
+import 'package:flowgroove/models/song_lab.dart';
+import 'package:flowgroove/providers/auth/auth_provider.dart';
+import 'package:flowgroove/providers/data/data_providers.dart';
+import 'package:flowgroove/repositories/firestore_lab_repository.dart';
+import 'package:flowgroove/screens/songs/song_lab_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../helpers/mocks.mocks.dart';
+
+class _InMemoryLabRepo extends FirestoreLabRepository {
+  _InMemoryLabRepo()
+    : super(firestore: MockFirebaseFirestore(), auth: MockFirebaseAuth());
+
+  final entries = <SongLabEntry>[];
+  final _controller = StreamController<List<SongLabEntry>>.broadcast();
+
+  void _emit() => _controller.add(List.of(entries));
+
+  @override
+  Stream<List<SongLabEntry>> watchEntries(String songId, {String? bandId}) {
+    scheduleMicrotask(_emit);
+    return _controller.stream;
+  }
+
+  @override
+  Future<void> saveEntry(SongLabEntry entry, {String? bandId}) async {
+    entries.removeWhere((e) => e.id == entry.id);
+    entries.insert(0, entry);
+    _emit();
+  }
+
+  @override
+  Future<void> deleteEntry(
+    String songId,
+    String entryId, {
+    String? bandId,
+  }) async {
+    entries.removeWhere((e) => e.id == entryId);
+    _emit();
+  }
+}
+
+void main() {
+  final song = Song(
+    id: 's1',
+    title: 'Hey Joe',
+    artist: 'Jimi Hendrix',
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+    sections: [Section(id: 'sec1', name: 'Verse', duration: 4)],
+  );
+
+  Future<_InMemoryLabRepo> pump(WidgetTester tester, {Song? withSong}) async {
+    final repo = _InMemoryLabRepo();
+    final auth = MockFirebaseAuth();
+    when(auth.currentUser).thenReturn(null);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          labRepositoryProvider.overrideWithValue(repo),
+          firebaseAuthProvider.overrideWith((ref) => auth),
+        ],
+        child: MaterialApp(home: SongLabScreen(song: withSong ?? song)),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    return repo;
+  }
+
+  group('SongLabScreen (#67)', () {
+    testWidgets('shows quick-add chips and empty state', (tester) async {
+      await pump(tester);
+
+      expect(find.text('+ Note'), findsOneWidget);
+      expect(find.text('+ Decision'), findsOneWidget);
+      expect(find.text('+ Experiment'), findsOneWidget);
+      expect(find.text('+ Problem'), findsOneWidget);
+      expect(
+        find.text('The story of this song starts here'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('composing a note saves an entry and renders it', (
+      tester,
+    ) async {
+      final repo = await pump(tester);
+
+      await tester.tap(find.text('+ Note'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'What happened?'),
+        'Try the riff an octave up',
+      );
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(repo.entries, hasLength(1));
+      expect(repo.entries.single.type, LabEntryType.note);
+      expect(repo.entries.single.body, 'Try the riff an octave up');
+      expect(find.text('Try the riff an octave up'), findsOneWidget);
+    });
+
+    testWidgets('decision quick-add starts with active status', (
+      tester,
+    ) async {
+      final repo = await pump(tester);
+
+      await tester.tap(find.text('+ Decision'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'What happened?'),
+        'Half-time last chorus',
+      );
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(repo.entries.single.status, 'active');
+      expect(repo.entries.single.type, LabEntryType.decision);
+    });
+
+    testWidgets('migrates song.notes into the first entry', (tester) async {
+      final annotated = Song(
+        id: 's2',
+        title: 'Old Song',
+        artist: 'X',
+        notes: 'capo on 2',
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+      );
+      final repo = await pump(tester, withSong: annotated);
+      await tester.pumpAndSettle();
+
+      expect(repo.entries, hasLength(1));
+      expect(repo.entries.single.title, 'Imported notes');
+      expect(repo.entries.single.body, 'capo on 2');
+    });
+  });
+}


### PR DESCRIPTION
Closes #67. Stacked on #126 (data model).

- **Song Lab screen** (song card overflow → "Song Lab"; route `song-lab`): reverse-chronological typed-entry feed with per-type icons, status line, and section names.
- **Quick-add** covers the v1 four (+Note +Decision +Experiment +Problem) via one compose sheet (title optional, body, optional section binding from the song's map). Richer types stay model-only per the epic guardrail.
- **Lifecycles:** decisions are born `active` and get "Mark superseded" (strikethrough, never deleted); experiments move planned → tried/accepted/rejected from the entry menu.
- **Filter row** (All + 4 types), delete with snackbar **Undo**, lazy `song.notes` → "Imported notes" migration on first open of an empty Lab.
- Consent-gated `lab_entry_added{type}` through the HEART choke point.
- Tests: 4 widget tests (in-memory repo). Full suite green (1974), analyze 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)