### PR TITLE
fix(setlists): band/personal card behavior parity (#128)

### DIFF
--- a/lib/screens/bands/band_setlists_screen.dart
+++ b/lib/screens/bands/band_setlists_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -12,6 +11,7 @@ import '../../providers/data/metronome_provider.dart';
 import '../../providers/permissions_provider.dart';
 import '../../services/export/pdf_service.dart';
 import '../../services/export/setlist_export_sheet.dart';
+import '../../services/export/setlist_share.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/snackbar.dart';
 import '../../widgets/app_menu_sheet.dart';
@@ -145,6 +145,29 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
     await ref
         .read(firestoreProvider)
         .deleteBandSetlist(widget.band.id, setlist.id);
+    // Undo parity with the personal list (#128).
+    if (mounted) {
+      showAppSnackBar(
+        context,
+        'Setlist "${setlist.name}" deleted',
+        actionLabel: 'Undo',
+        analyticsAction: 'setlist_delete',
+        onAction: () async {
+          await ref
+              .read(firestoreProvider)
+              .saveBandSetlist(setlist, widget.band.id);
+        },
+      );
+    }
+  }
+
+  void _viewSetlist(Setlist setlist) {
+    // Read-only view on tap (P1-7), same as the personal list (#128).
+    context.pushNamed(
+      'setlist-view',
+      pathParameters: {'id': setlist.id},
+      extra: setlist,
+    );
   }
 
   void _editSetlist(Setlist setlist) {
@@ -259,6 +282,7 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
       onDelete: _canDelete
           ? (index) => _deleteSetlist(adapters[index].setlist)
           : null,
+      onTap: (index) => _viewSetlist(adapters[index].setlist),
       onEdit: _canEdit
           ? (index) => _editSetlist(adapters[index].setlist)
           : null,
@@ -266,13 +290,13 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
         final setlist = adapters[index].setlist;
         return [
           if (_canEdit)
-            _SetlistIconAction(
+            IconAction(
               icon: Icons.edit,
               tooltip: 'Edit setlist',
               color: MonoPulseColors.textSecondary,
               onPressed: () => _editSetlist(setlist),
             ),
-          _SetlistIconAction(
+          IconAction(
             icon: Icons.av_timer,
             tooltip: 'Open in metronome',
             color: MonoPulseColors.textSecondary,
@@ -280,6 +304,7 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
           ),
           OverflowMenuAction(
             entries: [
+              ('Share', Icons.share, () => _shareSetlist(setlist)),
               ('Copy links', Icons.link, () => _shareAsLinks(setlist)),
               ('Export PDF', Icons.picture_as_pdf, () => _exportPdf(setlist)),
             ],
@@ -335,52 +360,15 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
     }
   }
 
+  Future<void> _shareSetlist(Setlist setlist) async {
+    final songs = await _songsForSetlist(setlist);
+    if (!mounted) return;
+    shareSetlistLinks(context, setlist, songs);
+  }
+
   Future<void> _shareAsLinks(Setlist setlist) async {
     final songs = await _songsForSetlist(setlist);
     if (!mounted) return;
-    final buffer = StringBuffer();
-    buffer.writeln(setlist.name);
-    if (setlist.description != null) buffer.writeln(setlist.description);
-    buffer.writeln();
-    buffer.writeln('Songs:');
-    for (int i = 0; i < songs.length; i++) {
-      final song = songs[i];
-      buffer.writeln('${i + 1}. ${song.title} - ${song.artist}');
-      if (song.spotifyUrl != null) {
-        buffer.writeln('   ${song.spotifyUrl}');
-      } else {
-        final searchUrl = Uri.encodeComponent('${song.title} ${song.artist}');
-        buffer.writeln('   https://open.spotify.com/search/$searchUrl');
-      }
-    }
-    buffer.writeln();
-    buffer.writeln('Created with FlowGroove');
-
-    await Clipboard.setData(ClipboardData(text: buffer.toString()));
-    if (!mounted) return;
-    showAppSnackBar(context, 'Setlist links copied to clipboard!');
-  }
-}
-
-class _SetlistIconAction implements UnifiedItemAction {
-  _SetlistIconAction({
-    required this.icon,
-    required this.tooltip,
-    required this.onPressed,
-    this.color,
-  });
-
-  final IconData icon;
-  final String tooltip;
-  final VoidCallback onPressed;
-  final Color? color;
-
-  @override
-  Widget build(BuildContext context) {
-    return IconButton(
-      icon: Icon(icon, size: 20, color: color),
-      onPressed: onPressed,
-      tooltip: tooltip,
-    );
+    await copySetlistLinks(context, setlist, songs);
   }
 }

--- a/lib/screens/setlists/setlists_list_screen.dart
+++ b/lib/screens/setlists/setlists_list_screen.dart
@@ -10,6 +10,7 @@ import '../../providers/data/metronome_provider.dart';
 import '../../providers/permissions_provider.dart';
 import '../../services/export/pdf_service.dart';
 import '../../services/export/setlist_export_sheet.dart';
+import '../../services/export/setlist_share.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/snackbar.dart';
 import '../../widgets/app_menu_sheet.dart';
@@ -17,7 +18,6 @@ import '../../widgets/empty_state.dart';
 import '../../widgets/error_banner.dart' show ErrorBanner, ErrorBannerStyle;
 import '../../widgets/fab_variants.dart';
 import '../../widgets/loading_indicator.dart';
-import '../../widgets/share_sheet.dart';
 import '../../widgets/standard_screen_scaffold.dart';
 import '../../widgets/unified_item/adapters/setlist_item_adapter.dart';
 import '../../widgets/unified_item/unified_filter_sort_widget.dart';
@@ -268,6 +268,14 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
       additionalActionsBuilder: (index) {
         final setlist = adapters[index].setlist;
         return [
+          // Direct-edit shortcut, parity with the band list (#128).
+          if (canEdit)
+            IconAction(
+              icon: Icons.edit,
+              tooltip: 'Edit setlist',
+              color: MonoPulseColors.textSecondary,
+              onPressed: () => _handleEdit(index),
+            ),
           IconAction(
             icon: Icons.av_timer,
             tooltip: 'Open in metronome',
@@ -277,6 +285,7 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
           OverflowMenuAction(
             entries: [
               ('Share', Icons.share, () => _shareSetlist(setlist)),
+              ('Copy links', Icons.link, () => _copyLinks(setlist)),
               ('Export PDF', Icons.picture_as_pdf, () => _exportPdf(setlist)),
             ],
           ),
@@ -311,7 +320,13 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
   Future<void> _shareSetlist(Setlist setlist) async {
     final songs = await _songsForSetlist(setlist);
     if (!mounted) return;
-    _shareAsLinks(context, setlist, songs);
+    shareSetlistLinks(context, setlist, songs);
+  }
+
+  Future<void> _copyLinks(Setlist setlist) async {
+    final songs = await _songsForSetlist(setlist);
+    if (!mounted) return;
+    await copySetlistLinks(context, setlist, songs);
   }
 
   Future<void> _exportPdf(Setlist setlist) async {
@@ -326,24 +341,4 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
     }
   }
 
-  void _shareAsLinks(BuildContext context, Setlist setlist, List<Song> songs) {
-    final buffer = StringBuffer();
-    buffer.writeln('🎵 ${setlist.name}');
-    if (setlist.description != null) buffer.writeln(setlist.description);
-    buffer.writeln();
-    buffer.writeln('Songs:');
-    for (int i = 0; i < songs.length; i++) {
-      final song = songs[i];
-      buffer.writeln('${i + 1}. ${song.title} - ${song.artist}');
-      if (song.spotifyUrl != null) {
-        buffer.writeln('   🎧 ${song.spotifyUrl}');
-      } else {
-        final searchUrl = Uri.encodeComponent('${song.title} ${song.artist}');
-        buffer.writeln('   🔍 https://open.spotify.com/search/$searchUrl');
-      }
-    }
-    buffer.writeln();
-    buffer.writeln('Created with FlowGroove');
-    showShareSheet(context, buffer.toString(), subject: setlist.name);
-  }
 }

--- a/lib/services/export/setlist_share.dart
+++ b/lib/services/export/setlist_share.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../models/setlist.dart';
+import '../../models/song.dart';
+import '../../utils/snackbar.dart';
+import '../../widgets/share_sheet.dart';
+
+/// Shared setlist share body + delivery modes (#128) — one text builder for
+/// both the personal and band screens, so "Share" and "Copy links" behave
+/// identically everywhere.
+String setlistShareText(Setlist setlist, List<Song> songs) {
+  final buffer = StringBuffer();
+  buffer.writeln('🎵 ${setlist.name}');
+  if (setlist.description != null) buffer.writeln(setlist.description);
+  buffer.writeln();
+  buffer.writeln('Songs:');
+  for (int i = 0; i < songs.length; i++) {
+    final song = songs[i];
+    buffer.writeln('${i + 1}. ${song.title} - ${song.artist}');
+    if (song.spotifyUrl != null) {
+      buffer.writeln('   🎧 ${song.spotifyUrl}');
+    } else {
+      final searchUrl = Uri.encodeComponent('${song.title} ${song.artist}');
+      buffer.writeln('   🔍 https://open.spotify.com/search/$searchUrl');
+    }
+  }
+  buffer.writeln();
+  buffer.writeln('Created with FlowGroove');
+  return buffer.toString();
+}
+
+/// Opens the native share sheet with the setlist links body.
+void shareSetlistLinks(BuildContext context, Setlist setlist, List<Song> songs) {
+  showShareSheet(context, setlistShareText(setlist, songs), subject: setlist.name);
+}
+
+/// Copies the setlist links body to the clipboard with a confirmation.
+Future<void> copySetlistLinks(
+  BuildContext context,
+  Setlist setlist,
+  List<Song> songs,
+) async {
+  await Clipboard.setData(ClipboardData(text: setlistShareText(setlist, songs)));
+  if (!context.mounted) return;
+  showAppSnackBar(context, 'Setlist links copied to clipboard!');
+}

--- a/test/screens/bands/band_setlists_screen_test.dart
+++ b/test/screens/bands/band_setlists_screen_test.dart
@@ -168,7 +168,7 @@ void main() {
       final firebaseUser = MockUser();
       when(firebaseUser.uid).thenReturn('test-user-id');
 
-      final router = await pumpRoutedTestApp(
+      await pumpRoutedTestApp(
         tester,
         initialLocation: '/main/bands/band-123/setlists',
         routes: _routesFor(band),
@@ -197,11 +197,15 @@ void main() {
 
       expect(find.text('Friday Gig'), findsOneWidget);
       expect(find.byType(FloatingActionButton), findsNothing);
+      // No edit pencil for viewers.
+      expect(find.byIcon(Icons.edit), findsNothing);
 
+      // Tap opens the read-only view for everyone (#128 parity with the
+      // personal list) — viewers get a read path instead of a dead tap.
       await tester.tap(find.text('Friday Gig'));
       await tester.pumpAndSettle();
 
-      expect(currentRouterUri(router).path, '/main/bands/band-123/setlists');
+      expect(find.text('route:setlist-view'), findsOneWidget);
     });
 
     testWidgets('demo admins can read setlists but cannot modify them', (
@@ -310,6 +314,11 @@ List<RouteBase> _routesFor(Band band) {
       path: '/main/setlists/:id/edit',
       name: 'edit-setlist',
       builder: (context, state) => const TestRouteMarker('edit-setlist'),
+    ),
+    GoRoute(
+      path: '/main/setlists/:id',
+      name: 'setlist-view',
+      builder: (context, state) => const TestRouteMarker('setlist-view'),
     ),
   ];
 }


### PR DESCRIPTION
Closes #128 (beta device feedback).

The setlist card visual was already one shared widget — the behaviors diverged per screen. Converged:

| Behavior | Before (band) | Now (both) |
|---|---|---|
| Tap | opened EDIT; dead tap for viewers | read-only view (P1-7) |
| Edit | pencil icon (band only) | pencil on both, edit-gated |
| Overflow | Copy links, Export PDF | **Share + Copy links + Export PDF** |
| Delete | no undo | Undo snackbar on both |
| Share body | plain, clipboard-only | one emoji body via new `setlist_share.dart` (native sheet or clipboard) |

Kept (named exceptions): band delete admin-only, role-aware empty states, FAB labels, band-scope routing. Band's duplicate `_SetlistIconAction` class deleted in favor of shared `IconAction`.

Tests: viewer tap now asserts navigation to `setlist-view` (was asserting the dead tap), no-pencil-for-viewers added. Full suite green (1966), analyze 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)