### PR TITLE
feat(settings): global Settings screen (#129)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'providers/analytics_consent_provider.dart';
 import 'providers/auth/auth_provider.dart';
 import 'providers/keep_screen_on_provider.dart';
 import 'providers/metronome_runtime_providers.dart';
+import 'providers/theme_mode_provider.dart';
 import 'repositories/metronome_session_repository.dart';
 import 'router/app_router.dart';
 import 'services/analytics_service.dart';
@@ -279,9 +280,9 @@ class FlowGrooveApp extends ConsumerWidget {
     return MaterialApp.router(
       title: 'FlowGroove',
       debugShowCheckedModeBanner: false,
-      theme: MonoPulseTheme.theme,
+      theme: MonoPulseTheme.lightTheme,
       darkTheme: MonoPulseTheme.theme,
-      themeMode: ThemeMode.dark,
+      themeMode: ref.watch(themeModeProvider),
       routerConfig: appRouter,
       builder: (context, child) {
         // Handle loading state

--- a/lib/providers/data/metronome_provider.dart
+++ b/lib/providers/data/metronome_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:uuid/uuid.dart';
 
+import '../haptics_provider.dart';
 import '../../models/beat_mode.dart';
 import '../../models/metronome_preset.dart';
 import '../../models/metronome_runtime_state.dart';
@@ -62,7 +63,15 @@ class MetronomeNotifier extends Notifier<MetronomeState> {
     _wakelock = ref.read(wakelockProvider);
     ref.onDispose(_cleanup);
 
-    return MetronomeState.initial();
+    // Global haptics preference is the single source of truth (#129): the
+    // engine state follows it, both now and on later Settings toggles.
+    ref.listen<bool>(hapticsEnabledProvider, (_, enabled) {
+      if (state.hapticsEnabled != enabled) setHapticsEnabled(enabled);
+    });
+
+    return MetronomeState.initial().copyWith(
+      hapticsEnabled: ref.read(hapticsEnabledProvider),
+    );
   }
 
   /// Start the metronome
@@ -594,10 +603,14 @@ class MetronomeNotifier extends Notifier<MetronomeState> {
     setHapticsEnabled(!state.hapticsEnabled);
   }
 
-  /// Set synchronized haptic feedback during playback.
+  /// Set synchronized haptic feedback during playback. Writes through to the
+  /// global haptics preference (#129) so Settings and the Sound sheet agree.
   void setHapticsEnabled(bool enabled) {
     state = state.copyWith(hapticsEnabled: enabled);
     _syncPlaybackConfig();
+    if (ref.read(hapticsEnabledProvider) != enabled) {
+      ref.read(hapticsEnabledProvider.notifier).set(enabled);
+    }
   }
 
   /// Set accent pattern

--- a/lib/providers/haptics_provider.dart
+++ b/lib/providers/haptics_provider.dart
@@ -1,0 +1,60 @@
+/// Global haptics preference (#129) — the single source of truth for
+/// vibration feedback app-wide. The metronome's Sound-sheet toggle binds to
+/// this provider; the metronome engine state follows it.
+library;
+
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _hapticsKey = 'app.haptics';
+
+class HapticsEnabled extends Notifier<bool> {
+  @override
+  bool build() {
+    _load();
+    return true;
+  }
+
+  /// Prefs may be unavailable (pure-Dart tests, startup races) — the
+  /// preference then simply isn't persisted for this session.
+  Future<SharedPreferences?> get _prefs async {
+    try {
+      return await SharedPreferences.getInstance();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _load() async {
+    final prefs = await _prefs;
+    if (prefs == null) return;
+    var value = prefs.getBool(_hapticsKey);
+    if (value == null) {
+      // One-time migration: haptics used to live inside the metronome's
+      // persisted manual-settings blob.
+      final blob = prefs.getString('metronome.last_manual_settings');
+      if (blob != null) {
+        try {
+          value =
+              (json.decode(blob) as Map<String, dynamic>)['hapticsEnabled']
+                  as bool?;
+        } catch (_) {}
+      }
+      value ??= true;
+      await prefs.setBool(_hapticsKey, value);
+    }
+    state = value;
+  }
+
+  Future<void> set(bool value) async {
+    state = value;
+    await (await _prefs)?.setBool(_hapticsKey, value);
+  }
+
+  Future<void> toggle() => set(!state);
+}
+
+final hapticsEnabledProvider =
+    NotifierProvider<HapticsEnabled, bool>(HapticsEnabled.new);

--- a/lib/providers/theme_mode_provider.dart
+++ b/lib/providers/theme_mode_provider.dart
@@ -1,0 +1,37 @@
+/// Global theme preference (#129): system / dark / light. Default dark —
+/// the app's native look. Light is beta: Material surfaces flip, but
+/// custom widgets that hardcode MonoPulseColors stay dark-toned until the
+/// palette migration (follow-up issue).
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _themeModeKey = 'app.theme_mode';
+
+class AppThemeMode extends Notifier<ThemeMode> {
+  @override
+  ThemeMode build() {
+    _load();
+    return ThemeMode.dark;
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final name = prefs.getString(_themeModeKey);
+    state = ThemeMode.values.firstWhere(
+      (m) => m.name == name,
+      orElse: () => ThemeMode.dark,
+    );
+  }
+
+  Future<void> set(ThemeMode mode) async {
+    state = mode;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_themeModeKey, mode.name);
+  }
+}
+
+final themeModeProvider =
+    NotifierProvider<AppThemeMode, ThemeMode>(AppThemeMode.new);

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -37,6 +37,7 @@ import '../screens/setlists/create_setlist_screen.dart';
 import '../screens/setlists/setlist_view_screen.dart';
 import '../screens/setlists/setlists_list_screen.dart';
 import '../screens/songs/add_song_screen.dart';
+import '../screens/settings/app_settings_screen.dart';
 import '../screens/songs/canonical_browse_screen.dart';
 import '../screens/songs/models/song_form_data.dart';
 import '../screens/songs/song_duplicates_screen.dart';
@@ -543,6 +544,12 @@ List<RouteBase> _buildAppRoutes() {
               : null,
         );
       },
+    ),
+    GoRoute(
+      path: '/main/settings',
+      name: 'settings',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) => const AppSettingsScreen(),
     ),
     GoRoute(
       path: '/main/join-band',

--- a/lib/screens/bands/band_setlists_screen.dart
+++ b/lib/screens/bands/band_setlists_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -12,6 +11,7 @@ import '../../providers/data/metronome_provider.dart';
 import '../../providers/permissions_provider.dart';
 import '../../services/export/pdf_service.dart';
 import '../../services/export/setlist_export_sheet.dart';
+import '../../services/export/setlist_share.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/snackbar.dart';
 import '../../widgets/app_menu_sheet.dart';
@@ -145,6 +145,29 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
     await ref
         .read(firestoreProvider)
         .deleteBandSetlist(widget.band.id, setlist.id);
+    // Undo parity with the personal list (#128).
+    if (mounted) {
+      showAppSnackBar(
+        context,
+        'Setlist "${setlist.name}" deleted',
+        actionLabel: 'Undo',
+        analyticsAction: 'setlist_delete',
+        onAction: () async {
+          await ref
+              .read(firestoreProvider)
+              .saveBandSetlist(setlist, widget.band.id);
+        },
+      );
+    }
+  }
+
+  void _viewSetlist(Setlist setlist) {
+    // Read-only view on tap (P1-7), same as the personal list (#128).
+    context.pushNamed(
+      'setlist-view',
+      pathParameters: {'id': setlist.id},
+      extra: setlist,
+    );
   }
 
   void _editSetlist(Setlist setlist) {
@@ -259,6 +282,7 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
       onDelete: _canDelete
           ? (index) => _deleteSetlist(adapters[index].setlist)
           : null,
+      onTap: (index) => _viewSetlist(adapters[index].setlist),
       onEdit: _canEdit
           ? (index) => _editSetlist(adapters[index].setlist)
           : null,
@@ -266,13 +290,13 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
         final setlist = adapters[index].setlist;
         return [
           if (_canEdit)
-            _SetlistIconAction(
+            IconAction(
               icon: Icons.edit,
               tooltip: 'Edit setlist',
               color: MonoPulseColors.textSecondary,
               onPressed: () => _editSetlist(setlist),
             ),
-          _SetlistIconAction(
+          IconAction(
             icon: Icons.av_timer,
             tooltip: 'Open in metronome',
             color: MonoPulseColors.textSecondary,
@@ -280,6 +304,7 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
           ),
           OverflowMenuAction(
             entries: [
+              ('Share', Icons.share, () => _shareSetlist(setlist)),
               ('Copy links', Icons.link, () => _shareAsLinks(setlist)),
               ('Export PDF', Icons.picture_as_pdf, () => _exportPdf(setlist)),
             ],
@@ -335,52 +360,15 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
     }
   }
 
+  Future<void> _shareSetlist(Setlist setlist) async {
+    final songs = await _songsForSetlist(setlist);
+    if (!mounted) return;
+    shareSetlistLinks(context, setlist, songs);
+  }
+
   Future<void> _shareAsLinks(Setlist setlist) async {
     final songs = await _songsForSetlist(setlist);
     if (!mounted) return;
-    final buffer = StringBuffer();
-    buffer.writeln(setlist.name);
-    if (setlist.description != null) buffer.writeln(setlist.description);
-    buffer.writeln();
-    buffer.writeln('Songs:');
-    for (int i = 0; i < songs.length; i++) {
-      final song = songs[i];
-      buffer.writeln('${i + 1}. ${song.title} - ${song.artist}');
-      if (song.spotifyUrl != null) {
-        buffer.writeln('   ${song.spotifyUrl}');
-      } else {
-        final searchUrl = Uri.encodeComponent('${song.title} ${song.artist}');
-        buffer.writeln('   https://open.spotify.com/search/$searchUrl');
-      }
-    }
-    buffer.writeln();
-    buffer.writeln('Created with FlowGroove');
-
-    await Clipboard.setData(ClipboardData(text: buffer.toString()));
-    if (!mounted) return;
-    showAppSnackBar(context, 'Setlist links copied to clipboard!');
-  }
-}
-
-class _SetlistIconAction implements UnifiedItemAction {
-  _SetlistIconAction({
-    required this.icon,
-    required this.tooltip,
-    required this.onPressed,
-    this.color,
-  });
-
-  final IconData icon;
-  final String tooltip;
-  final VoidCallback onPressed;
-  final Color? color;
-
-  @override
-  Widget build(BuildContext context) {
-    return IconButton(
-      icon: Icon(icon, size: 20, color: color),
-      onPressed: onPressed,
-      tooltip: tooltip,
-    );
+    await copySetlistLinks(context, setlist, songs);
   }
 }

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -27,10 +27,7 @@ import '../../utils/web_version_loader_export.dart';
 import '../../widgets/role_picker_widget.dart';
 import '../../widgets/standard_screen_scaffold.dart';
 import '../../widgets/support_sheet.dart';
-import '../providers/analytics_consent_provider.dart';
-import '../providers/keep_screen_on_provider.dart';
 import '../utils/snackbar.dart';
-import 'settings/api_access_screen.dart';
 
 class ProfileScreen extends ConsumerStatefulWidget {
   const ProfileScreen({super.key});
@@ -513,8 +510,6 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
     final appUserAsync = ref.watch(appUserProvider);
     // Demo is a shared public account: hide all profile-editing affordances.
     final isDemo = ref.watch(isDemoUserProvider);
-    final keepScreenOn = ref.watch(keepScreenOnProvider);
-    final analyticsConsent = ref.watch(analyticsConsentProvider);
 
     final displayName =
         appUserAsync.whenOrNull(data: (u) => u?.displayName) ??
@@ -660,39 +655,8 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                   subtitle: 'Get name and photo from Telegram',
                   onTap: _showTelegramLinkDialog,
                 ),
-              _buildMenuItem(
-                icon: Icons.smart_toy_outlined,
-                title: 'AI access (MCP)',
-                subtitle: 'Connect your own AI to read & add songs',
-                onTap: () => Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const ApiAccessScreen(),
-                  ),
-                ),
-              ),
-              SwitchListTile(
-                secondary: const Icon(
-                  Icons.lightbulb_outline,
-                  color: MonoPulseColors.accentOrange,
-                ),
-                title: const Text('Keep screen on'),
-                value: keepScreenOn,
-                onChanged: (_) =>
-                    ref.read(keepScreenOnProvider.notifier).toggle(),
-              ),
-              SwitchListTile(
-                secondary: const Icon(
-                  Icons.analytics_outlined,
-                  color: MonoPulseColors.accentOrange,
-                ),
-                title: const Text('Share usage analytics'),
-                subtitle: const Text(
-                  'Helps us see which features get used',
-                ),
-                value: analyticsConsent,
-                onChanged: (_) =>
-                    ref.read(analyticsConsentProvider.notifier).toggle(),
-              ),
+              // Keep screen on / analytics / AI access moved to the global
+              // Settings screen (#129) — one control, one home.
             ],
           ),
           const SizedBox(height: MonoPulseSpacing.lg),

--- a/lib/screens/setlists/setlists_list_screen.dart
+++ b/lib/screens/setlists/setlists_list_screen.dart
@@ -10,6 +10,7 @@ import '../../providers/data/metronome_provider.dart';
 import '../../providers/permissions_provider.dart';
 import '../../services/export/pdf_service.dart';
 import '../../services/export/setlist_export_sheet.dart';
+import '../../services/export/setlist_share.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/snackbar.dart';
 import '../../widgets/app_menu_sheet.dart';
@@ -17,7 +18,6 @@ import '../../widgets/empty_state.dart';
 import '../../widgets/error_banner.dart' show ErrorBanner, ErrorBannerStyle;
 import '../../widgets/fab_variants.dart';
 import '../../widgets/loading_indicator.dart';
-import '../../widgets/share_sheet.dart';
 import '../../widgets/standard_screen_scaffold.dart';
 import '../../widgets/unified_item/adapters/setlist_item_adapter.dart';
 import '../../widgets/unified_item/unified_filter_sort_widget.dart';
@@ -268,6 +268,14 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
       additionalActionsBuilder: (index) {
         final setlist = adapters[index].setlist;
         return [
+          // Direct-edit shortcut, parity with the band list (#128).
+          if (canEdit)
+            IconAction(
+              icon: Icons.edit,
+              tooltip: 'Edit setlist',
+              color: MonoPulseColors.textSecondary,
+              onPressed: () => _handleEdit(index),
+            ),
           IconAction(
             icon: Icons.av_timer,
             tooltip: 'Open in metronome',
@@ -277,6 +285,7 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
           OverflowMenuAction(
             entries: [
               ('Share', Icons.share, () => _shareSetlist(setlist)),
+              ('Copy links', Icons.link, () => _copyLinks(setlist)),
               ('Export PDF', Icons.picture_as_pdf, () => _exportPdf(setlist)),
             ],
           ),
@@ -311,7 +320,13 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
   Future<void> _shareSetlist(Setlist setlist) async {
     final songs = await _songsForSetlist(setlist);
     if (!mounted) return;
-    _shareAsLinks(context, setlist, songs);
+    shareSetlistLinks(context, setlist, songs);
+  }
+
+  Future<void> _copyLinks(Setlist setlist) async {
+    final songs = await _songsForSetlist(setlist);
+    if (!mounted) return;
+    await copySetlistLinks(context, setlist, songs);
   }
 
   Future<void> _exportPdf(Setlist setlist) async {
@@ -326,24 +341,4 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
     }
   }
 
-  void _shareAsLinks(BuildContext context, Setlist setlist, List<Song> songs) {
-    final buffer = StringBuffer();
-    buffer.writeln('🎵 ${setlist.name}');
-    if (setlist.description != null) buffer.writeln(setlist.description);
-    buffer.writeln();
-    buffer.writeln('Songs:');
-    for (int i = 0; i < songs.length; i++) {
-      final song = songs[i];
-      buffer.writeln('${i + 1}. ${song.title} - ${song.artist}');
-      if (song.spotifyUrl != null) {
-        buffer.writeln('   🎧 ${song.spotifyUrl}');
-      } else {
-        final searchUrl = Uri.encodeComponent('${song.title} ${song.artist}');
-        buffer.writeln('   🔍 https://open.spotify.com/search/$searchUrl');
-      }
-    }
-    buffer.writeln();
-    buffer.writeln('Created with FlowGroove');
-    showShareSheet(context, buffer.toString(), subject: setlist.name);
-  }
 }

--- a/lib/screens/settings/app_settings_screen.dart
+++ b/lib/screens/settings/app_settings_screen.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../providers/analytics_consent_provider.dart';
+import '../../providers/haptics_provider.dart';
+import '../../providers/keep_screen_on_provider.dart';
+import '../../providers/theme_mode_provider.dart';
+import '../../theme/mono_pulse_theme.dart';
+import '../../widgets/standard_screen_scaffold.dart';
+import '../../widgets/unified_item/song_card_actions.dart';
+import 'api_access_screen.dart';
+
+/// Global app settings (#129) — the single home for app-wide preferences,
+/// reachable from the main-menu 3-dots on every tab. Profile keeps only
+/// account things.
+class AppSettingsScreen extends ConsumerStatefulWidget {
+  const AppSettingsScreen({super.key});
+
+  @override
+  ConsumerState<AppSettingsScreen> createState() => _AppSettingsScreenState();
+}
+
+class _AppSettingsScreenState extends ConsumerState<AppSettingsScreen> {
+  static const _latencyKey = 'metronome_latency_offset_ms';
+  int _latencyMs = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    SharedPreferences.getInstance().then((prefs) {
+      if (mounted) {
+        setState(() => _latencyMs = prefs.getInt(_latencyKey) ?? 0);
+      }
+    });
+  }
+
+  Future<void> _setLatency(int ms) async {
+    final clamped = ms.clamp(-200, 500);
+    setState(() => _latencyMs = clamped);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_latencyKey, clamped);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final keepScreenOn = ref.watch(keepScreenOnProvider);
+    final haptics = ref.watch(hapticsEnabledProvider);
+    final analyticsConsent = ref.watch(analyticsConsentProvider);
+    final themeMode = ref.watch(themeModeProvider);
+
+    return StandardScreenScaffold(
+      title: 'Settings',
+      body: ListView(
+        padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+        children: [
+          _section(context, 'General', [
+            SwitchListTile(
+              secondary: const Icon(
+                Icons.lightbulb_outline,
+                color: MonoPulseColors.accentOrange,
+              ),
+              title: const Text('Keep screen on'),
+              subtitle: const Text('Never dim while FlowGroove is open'),
+              value: keepScreenOn,
+              onChanged: (_) =>
+                  ref.read(keepScreenOnProvider.notifier).toggle(),
+            ),
+            SwitchListTile(
+              secondary: const Icon(
+                Icons.vibration,
+                color: MonoPulseColors.accentOrange,
+              ),
+              title: const Text('Haptics'),
+              subtitle: const Text('Vibration feedback, incl. metronome'),
+              value: haptics,
+              onChanged: (_) =>
+                  ref.read(hapticsEnabledProvider.notifier).toggle(),
+            ),
+            ListTile(
+              leading: const Icon(
+                Icons.dark_mode_outlined,
+                color: MonoPulseColors.accentOrange,
+              ),
+              title: const Text('Theme'),
+              trailing: SegmentedButton<ThemeMode>(
+                segments: const [
+                  ButtonSegment(
+                    value: ThemeMode.system,
+                    label: Text('Auto'),
+                  ),
+                  ButtonSegment(value: ThemeMode.dark, label: Text('Dark')),
+                  ButtonSegment(
+                    value: ThemeMode.light,
+                    label: Text('Light β'),
+                  ),
+                ],
+                selected: {themeMode},
+                onSelectionChanged: (s) =>
+                    ref.read(themeModeProvider.notifier).set(s.first),
+              ),
+            ),
+          ]),
+          const SizedBox(height: MonoPulseSpacing.lg),
+          _section(context, 'Songs', [
+            ListTile(
+              leading: const Icon(
+                Icons.push_pin_outlined,
+                color: MonoPulseColors.accentOrange,
+              ),
+              title: const Text('Quick action on song cards'),
+              subtitle: const Text('What the pinned card button does'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => showQuickActionPicker(context, ref),
+            ),
+          ]),
+          const SizedBox(height: MonoPulseSpacing.lg),
+          _section(context, 'Privacy', [
+            SwitchListTile(
+              secondary: const Icon(
+                Icons.analytics_outlined,
+                color: MonoPulseColors.accentOrange,
+              ),
+              title: const Text('Share usage analytics'),
+              subtitle: const Text('Helps us see which features get used'),
+              value: analyticsConsent,
+              onChanged: (_) =>
+                  ref.read(analyticsConsentProvider.notifier).toggle(),
+            ),
+          ]),
+          const SizedBox(height: MonoPulseSpacing.lg),
+          _section(context, 'AI', [
+            ListTile(
+              leading: const Icon(
+                Icons.smart_toy_outlined,
+                color: MonoPulseColors.accentOrange,
+              ),
+              title: const Text('AI access (MCP)'),
+              subtitle: const Text('Connect your own AI to read & add songs'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const ApiAccessScreen(),
+                ),
+              ),
+            ),
+          ]),
+          const SizedBox(height: MonoPulseSpacing.lg),
+          _section(context, 'Advanced', [
+            ListTile(
+              leading: const Icon(
+                Icons.timer_outlined,
+                color: MonoPulseColors.accentOrange,
+              ),
+              title: const Text('Audio latency offset'),
+              subtitle: const Text(
+                'Shift the metronome click if your audio route lags',
+              ),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.remove),
+                    onPressed: () => _setLatency(_latencyMs - 10),
+                  ),
+                  Text('$_latencyMs ms'),
+                  IconButton(
+                    icon: const Icon(Icons.add),
+                    onPressed: () => _setLatency(_latencyMs + 10),
+                  ),
+                ],
+              ),
+            ),
+          ]),
+        ],
+      ),
+    );
+  }
+
+  Widget _section(BuildContext context, String title, List<Widget> children) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(
+            left: MonoPulseSpacing.sm,
+            bottom: MonoPulseSpacing.sm,
+          ),
+          child: Text(title, style: Theme.of(context).textTheme.titleMedium),
+        ),
+        Card(child: Column(children: children)),
+      ],
+    );
+  }
+}

--- a/lib/services/export/setlist_share.dart
+++ b/lib/services/export/setlist_share.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../models/setlist.dart';
+import '../../models/song.dart';
+import '../../utils/snackbar.dart';
+import '../../widgets/share_sheet.dart';
+
+/// Shared setlist share body + delivery modes (#128) — one text builder for
+/// both the personal and band screens, so "Share" and "Copy links" behave
+/// identically everywhere.
+String setlistShareText(Setlist setlist, List<Song> songs) {
+  final buffer = StringBuffer();
+  buffer.writeln('🎵 ${setlist.name}');
+  if (setlist.description != null) buffer.writeln(setlist.description);
+  buffer.writeln();
+  buffer.writeln('Songs:');
+  for (int i = 0; i < songs.length; i++) {
+    final song = songs[i];
+    buffer.writeln('${i + 1}. ${song.title} - ${song.artist}');
+    if (song.spotifyUrl != null) {
+      buffer.writeln('   🎧 ${song.spotifyUrl}');
+    } else {
+      final searchUrl = Uri.encodeComponent('${song.title} ${song.artist}');
+      buffer.writeln('   🔍 https://open.spotify.com/search/$searchUrl');
+    }
+  }
+  buffer.writeln();
+  buffer.writeln('Created with FlowGroove');
+  return buffer.toString();
+}
+
+/// Opens the native share sheet with the setlist links body.
+void shareSetlistLinks(BuildContext context, Setlist setlist, List<Song> songs) {
+  showShareSheet(context, setlistShareText(setlist, songs), subject: setlist.name);
+}
+
+/// Copies the setlist links body to the clipboard with a confirmation.
+Future<void> copySetlistLinks(
+  BuildContext context,
+  Setlist setlist,
+  List<Song> songs,
+) async {
+  await Clipboard.setData(ClipboardData(text: setlistShareText(setlist, songs)));
+  if (!context.mounted) return;
+  showAppSnackBar(context, 'Setlist links copied to clipboard!');
+}

--- a/lib/theme/mono_pulse_theme.dart
+++ b/lib/theme/mono_pulse_theme.dart
@@ -378,6 +378,23 @@ class MonoPulseBorder {
 
 /// Mono Pulse Dark Theme (ONLY THEME - dark-only)
 class MonoPulseTheme {
+  /// Light variant, "Light (beta)" in Settings (#129). Material surfaces get
+  /// a real light scheme around the brand orange.
+  // ponytail: seed-derived scheme only — widgets that hardcode
+  // MonoPulseColors.* stay dark-toned until the palette migration issue.
+  static ThemeData get lightTheme {
+    final scheme = ColorScheme.fromSeed(
+      seedColor: MonoPulseColors.accentOrange,
+      brightness: Brightness.light,
+    );
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.light,
+      colorScheme: scheme,
+      scaffoldBackgroundColor: const Color(0xFFF7F5F2),
+    );
+  }
+
   static ThemeData get theme {
     return ThemeData(
       useMaterial3: true,

--- a/lib/widgets/app_menu_sheet.dart
+++ b/lib/widgets/app_menu_sheet.dart
@@ -108,6 +108,7 @@ Future<void> showAppMenuSheet(
                           color: MonoPulseColors.borderSubtle,
                         ),
                         _ProfileRow(ref: ref, sheetContext: sheetContext),
+                        _SettingsRow(sheetContext: sheetContext),
                       ],
                     ],
                   ),
@@ -160,6 +161,37 @@ class _AppMenuRow extends StatelessWidget {
               final onTap = item.onTap!;
               WidgetsBinding.instance.addPostFrameCallback((_) => onTap());
             },
+    );
+  }
+}
+
+/// Global "Settings" row (#129), listed right after Profile on root tabs.
+class _SettingsRow extends StatelessWidget {
+  const _SettingsRow({required this.sheetContext});
+
+  final BuildContext sheetContext;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const Icon(
+        Icons.settings_outlined,
+        size: 22,
+        color: MonoPulseColors.textHighEmphasis,
+      ),
+      title: Text(
+        'Settings',
+        style: MonoPulseTypography.bodyMedium.copyWith(
+          color: MonoPulseColors.textHighEmphasis,
+        ),
+      ),
+      onTap: () {
+        final router = GoRouter.of(context);
+        Navigator.of(sheetContext).pop();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          router.pushNamed('settings');
+        });
+      },
     );
   }
 }

--- a/lib/widgets/unified_item/song_card_actions.dart
+++ b/lib/widgets/unified_item/song_card_actions.dart
@@ -56,6 +56,45 @@ final songQuickActionProvider =
 /// The song-card action set (pinned quick action + overflow menu) shared by
 /// every screen that renders songs as unified item cards, so the cards behave
 /// identically in the personal and band libraries.
+/// Quick-action picker sheet — shared by the song-card overflow and the
+/// Settings screen (#129).
+Future<void> showQuickActionPicker(BuildContext context, WidgetRef ref) async {
+  final current = ref.read(songQuickActionProvider);
+  final choice = await showModalBottomSheet<String>(
+    context: context,
+    builder: (context) => SafeArea(
+      child: RadioGroup<String>(
+        groupValue: current,
+        onChanged: (v) => Navigator.pop(context, v),
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            const ListTile(
+              title: Text('Quick action'),
+              subtitle: Text(
+                'Sets what the pinned button on song cards does',
+              ),
+            ),
+            for (final MapEntry(: key, : value)
+                in SongCardActions.quickActions.entries)
+              RadioListTile<String>(
+                value: key,
+                title: Text(value.$1),
+                secondary: Icon(value.$2),
+              ),
+          ],
+        ),
+      ),
+    ),
+  );
+  if (choice != null && choice != current) {
+    await ref.read(songQuickActionProvider.notifier).set(choice);
+    if (!context.mounted) return;
+    final (label, _) = SongCardActions.quickActions[choice]!;
+    showAppSnackBar(context, 'Quick action set to $label');
+  }
+}
+
 mixin SongCardActions<T extends ConsumerStatefulWidget> on ConsumerState<T> {
   /// Band the songs on this screen belong to; null in the personal library.
   /// Drives where the metronome/tuner persist song changes.
@@ -136,41 +175,7 @@ mixin SongCardActions<T extends ConsumerStatefulWidget> on ConsumerState<T> {
   }
 
   /// Let the user choose which action is pinned on song cards.
-  Future<void> pickQuickAction() async {
-    final current = ref.read(songQuickActionProvider);
-    final choice = await showModalBottomSheet<String>(
-      context: context,
-      builder: (context) => SafeArea(
-        child: RadioGroup<String>(
-          groupValue: current,
-          onChanged: (v) => Navigator.pop(context, v),
-          child: ListView(
-            shrinkWrap: true,
-            children: [
-              const ListTile(
-                title: Text('Quick action'),
-                subtitle: Text(
-                  'Sets what the pinned button on song cards does',
-                ),
-              ),
-              for (final MapEntry(: key, : value) in quickActions.entries)
-                RadioListTile<String>(
-                  value: key,
-                  title: Text(value.$1),
-                  secondary: Icon(value.$2),
-                ),
-            ],
-          ),
-        ),
-      ),
-    );
-    if (choice != null && choice != current) {
-      await ref.read(songQuickActionProvider.notifier).set(choice);
-      if (!mounted) return;
-      final (label, _) = quickActions[choice]!;
-      showAppSnackBar(context, 'Quick action set to $label');
-    }
-  }
+  Future<void> pickQuickAction() => showQuickActionPicker(context, ref);
 
   /// One "Add to band…" entry instead of one per band — opens a picker.
   Future<void> pickBandAndAdd(Song song, List<Band> bands) async {

--- a/site/content/wiki/profile.md
+++ b/site/content/wiki/profile.md
@@ -4,13 +4,11 @@ title: "Profile"
 
 # Profile
 
-Your account and app settings. Open it from **Menu (⋯)** in the bottom bar.
+Your account. Open it from **Menu (⋯)** in the bottom bar. App-wide
+preferences live in [Settings](../settings/).
 
 - Update your display name and photo.
-- **Keep screen on** — stops the display sleeping during practice.
-- **Share usage analytics** — anonymous usage events that help improve the
-  app; switch it off any time and nothing is sent.
-- Manage preferences.
-- **AI access (MCP)** — create API keys to connect your own AI (see [AI & Import](../ai-and-import/)).
+- Set your music roles.
+- **Link Telegram** — get your name/photo and band notifications there.
 - Sign out from the button at the bottom of this screen.
 - **Delete account** (at the bottom) permanently removes your account and all your data.

--- a/site/content/wiki/settings.md
+++ b/site/content/wiki/settings.md
@@ -1,0 +1,22 @@
+---
+title: "Settings"
+---
+
+# Settings
+
+All app-wide preferences in one place. Open **Menu (⋯)** in the bottom bar —
+Settings sits right under your profile.
+
+- **Keep screen on** — stops the display sleeping during practice.
+- **Haptics** — vibration feedback everywhere, including the metronome's
+  synchronized pulse. One switch; the metronome's Sound sheet shows the same
+  setting.
+- **Theme** — Dark (default), Light (beta), or follow the system.
+- **Quick action on song cards** — choose what the pinned ⏱ button on every
+  song card does: Metronome, Tuner, Performance sheet, Spotify, or Add to band.
+- **Share usage analytics** — anonymous usage events that help improve the
+  app; switch it off any time and nothing is sent.
+- **AI access (MCP)** — create API keys to connect your own AI
+  (see [AI & Import](../ai-and-import/)).
+- **Audio latency offset** — if your Bluetooth speaker makes the metronome
+  click feel late, nudge it here (±10 ms steps).

--- a/test/screens/bands/band_setlists_screen_test.dart
+++ b/test/screens/bands/band_setlists_screen_test.dart
@@ -168,7 +168,7 @@ void main() {
       final firebaseUser = MockUser();
       when(firebaseUser.uid).thenReturn('test-user-id');
 
-      final router = await pumpRoutedTestApp(
+      await pumpRoutedTestApp(
         tester,
         initialLocation: '/main/bands/band-123/setlists',
         routes: _routesFor(band),
@@ -197,11 +197,15 @@ void main() {
 
       expect(find.text('Friday Gig'), findsOneWidget);
       expect(find.byType(FloatingActionButton), findsNothing);
+      // No edit pencil for viewers.
+      expect(find.byIcon(Icons.edit), findsNothing);
 
+      // Tap opens the read-only view for everyone (#128 parity with the
+      // personal list) — viewers get a read path instead of a dead tap.
       await tester.tap(find.text('Friday Gig'));
       await tester.pumpAndSettle();
 
-      expect(currentRouterUri(router).path, '/main/bands/band-123/setlists');
+      expect(find.text('route:setlist-view'), findsOneWidget);
     });
 
     testWidgets('demo admins can read setlists but cannot modify them', (
@@ -310,6 +314,11 @@ List<RouteBase> _routesFor(Band band) {
       path: '/main/setlists/:id/edit',
       name: 'edit-setlist',
       builder: (context, state) => const TestRouteMarker('edit-setlist'),
+    ),
+    GoRoute(
+      path: '/main/setlists/:id',
+      name: 'setlist-view',
+      builder: (context, state) => const TestRouteMarker('setlist-view'),
     ),
   ];
 }

--- a/test/screens/settings/app_settings_screen_test.dart
+++ b/test/screens/settings/app_settings_screen_test.dart
@@ -1,0 +1,102 @@
+import 'package:flowgroove/providers/analytics_consent_provider.dart';
+import 'package:flowgroove/providers/haptics_provider.dart';
+import 'package:flowgroove/providers/keep_screen_on_provider.dart';
+import 'package:flowgroove/providers/theme_mode_provider.dart';
+import 'package:flowgroove/screens/settings/app_settings_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Future<ProviderContainer> pump(WidgetTester tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: AppSettingsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return container;
+  }
+
+  group('AppSettingsScreen (#129)', () {
+    testWidgets('shows all v1 settings rows', (tester) async {
+      await pump(tester);
+
+      expect(find.text('Keep screen on'), findsOneWidget);
+      expect(find.text('Haptics'), findsOneWidget);
+      expect(find.text('Theme'), findsOneWidget);
+      expect(find.text('Quick action on song cards'), findsOneWidget);
+      expect(find.text('Share usage analytics'), findsOneWidget);
+      expect(find.text('AI access (MCP)'), findsOneWidget);
+      await tester.scrollUntilVisible(
+        find.text('Audio latency offset'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(find.text('Audio latency offset'), findsOneWidget);
+    });
+
+    testWidgets('haptics switch flips the global provider', (tester) async {
+      final container = await pump(tester);
+
+      expect(container.read(hapticsEnabledProvider), isTrue);
+      await tester.tap(
+        find.widgetWithText(SwitchListTile, 'Haptics'),
+      );
+      await tester.pumpAndSettle();
+      expect(container.read(hapticsEnabledProvider), isFalse);
+    });
+
+    testWidgets('keep-screen-on and analytics switches flip providers', (
+      tester,
+    ) async {
+      final container = await pump(tester);
+
+      await tester.tap(find.widgetWithText(SwitchListTile, 'Keep screen on'));
+      await tester.pumpAndSettle();
+      expect(container.read(keepScreenOnProvider), isFalse);
+
+      await tester.tap(
+        find.widgetWithText(SwitchListTile, 'Share usage analytics'),
+      );
+      await tester.pumpAndSettle();
+      expect(container.read(analyticsConsentProvider), isFalse);
+    });
+
+    testWidgets('theme segmented switch sets themeModeProvider', (
+      tester,
+    ) async {
+      final container = await pump(tester);
+
+      expect(container.read(themeModeProvider), ThemeMode.dark);
+      await tester.tap(find.text('Light β'));
+      await tester.pumpAndSettle();
+      expect(container.read(themeModeProvider), ThemeMode.light);
+    });
+
+    testWidgets('latency stepper adjusts and clamps', (tester) async {
+      await pump(tester);
+      await tester.scrollUntilVisible(
+        find.text('Audio latency offset'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+      expect(find.text('10 ms'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.remove));
+      await tester.pumpAndSettle();
+      expect(find.text('0 ms'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #129 (beta feedback: "main menu 3-dots → settings for all app, after profile").

- **Menu**: every root tab's Menu sheet now shows **Settings** right under the Profile row; opens `/main/settings` (root-navigator push, works from any tab).
- **General**: Keep screen on (moved from Profile) · **Haptics** — new global `app.haptics` provider as the single source of truth: the metronome's Sound-sheet toggle and engine state bind to it (write-through both ways + one-time migration from the metronome settings blob) · **Theme** — System / Dark / **Light (beta)** (`app.theme_mode`; light is a seed-derived Material scheme — widgets hardcoding MonoPulseColors stay dark until the palette migration, follow-up issue coming).
- **Songs**: Quick action on song cards — the picker extracted to `showQuickActionPicker` and shared with the card overflow.
- **Privacy**: Share usage analytics (moved from Profile).
- **AI**: AI access (MCP) (moved from Profile).
- **Advanced**: Audio latency offset ±10 ms stepper (exposes the existing hidden `metronome_latency_offset_ms` pref).
- Profile keeps account-only items; wiki: `settings.md` added, `profile.md` trimmed.

Tests: 5 Settings widget tests (rows, provider flips, theme switch, latency clamp). Full suite green (1971), analyze 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)