### PR TITLE
feat(lab): tasks tab + rehearsal prep counts (#68)

### DIFF
--- a/lib/providers/data/data_providers.dart
+++ b/lib/providers/data/data_providers.dart
@@ -62,6 +62,16 @@ final labTasksProvider = StreamProvider.autoDispose
       return ref.watch(labRepositoryProvider).watchTasks(songId, bandId: bandId);
     });
 
+/// One-shot open-task count for a song — the rehearsal "what to prepare"
+/// line (#68). Key: (songId, bandId).
+final openTaskCountProvider = FutureProvider.autoDispose
+    .family<int, (String, String?)>((ref, key) {
+      final (songId, bandId) = key;
+      return ref
+          .watch(labRepositoryProvider)
+          .openTaskCount(songId, bandId: bandId);
+    });
+
 final labVersionsProvider = StreamProvider.autoDispose
     .family<List<SongVersion>, (String, String?)>((ref, key) {
       final (songId, bandId) = key;

--- a/lib/screens/bands/rehearsals/rehearsal_detail_screen.dart
+++ b/lib/screens/bands/rehearsals/rehearsal_detail_screen.dart
@@ -377,7 +377,7 @@ class _ConfirmedCard extends ConsumerWidget {
                   style: const TextStyle(fontWeight: FontWeight.w600)),
               const SizedBox(height: 4),
               for (final item in setlist.effectiveItems)
-                _songLine(songsById[item.songId]),
+                _songLine(ref, songsById[item.songId]),
             ],
             const SizedBox(height: 16),
             FilledButton.icon(
@@ -399,11 +399,17 @@ class _ConfirmedCard extends ConsumerWidget {
     );
   }
 
-  Widget _songLine(Song? song) {
+  Widget _songLine(WidgetRef ref, Song? song) {
     if (song == null) return const SizedBox.shrink();
+    // "What to prepare" (#68): open Song Lab tasks for this band song.
+    final openTasks =
+        ref.watch(openTaskCountProvider((song.id, band.id))).value ?? 0;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: MonoPulseSpacing.xxs),
-      child: Text('• ${song.title} — ${song.artist}'),
+      child: Text(
+        '• ${song.title} — ${song.artist}'
+        '${openTasks > 0 ? '  ·  $openTasks open task${openTasks == 1 ? '' : 's'}' : ''}',
+      ),
     );
   }
 

--- a/lib/screens/songs/song_lab_screen.dart
+++ b/lib/screens/songs/song_lab_screen.dart
@@ -4,12 +4,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 
+import '../../models/band.dart';
 import '../../models/song.dart';
 import '../../models/song_lab.dart';
 import '../../providers/auth/auth_provider.dart';
 import '../../providers/data/data_providers.dart';
 import '../../services/analytics_service.dart';
 import '../../theme/mono_pulse_theme.dart';
+import '../../utils/member_label.dart';
 import '../../utils/snackbar.dart';
 import '../../widgets/app_filter_chip.dart';
 import '../../widgets/empty_state.dart';
@@ -33,6 +35,7 @@ class _SongLabScreenState extends ConsumerState<SongLabScreen> {
 
   /// null = all types.
   LabEntryType? _typeFilter;
+  bool _showTasks = false;
   bool _migrated = false;
 
   (String, String?) get _key => (widget.song.id, widget.bandId);
@@ -153,47 +156,219 @@ class _SongLabScreenState extends ConsumerState<SongLabScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final entriesAsync = ref.watch(labEntriesProvider(_key));
-
     return StandardScreenScaffold(
       title: 'Lab — ${widget.song.title}',
-      body: entriesAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Failed to load Lab: $e')),
-        data: (entries) {
-          _migrateNotesIfNeeded(entries);
-          final visible = _typeFilter == null
-              ? entries
-              : entries.where((e) => e.type == _typeFilter).toList();
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              _quickAddRow(),
-              if (entries.isNotEmpty) _filterRow(),
-              Expanded(
-                child: visible.isEmpty
-                    ? EmptyState(
-                        icon: Icons.science_outlined,
-                        message: entries.isEmpty
-                            ? 'The story of this song starts here'
-                            : 'Nothing of this type yet',
-                        hint: entries.isEmpty
-                            ? 'Capture ideas, decisions ("why we play it '
-                                  'this way"), experiments and problems — '
-                                  'so the band never loses the context.'
-                            : null,
-                      )
-                    : ListView.builder(
-                        padding: const EdgeInsets.only(bottom: 96),
-                        itemCount: visible.length,
-                        itemBuilder: (context, i) => _entryCard(visible[i]),
-                      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              MonoPulseSpacing.lg,
+              MonoPulseSpacing.md,
+              MonoPulseSpacing.lg,
+              0,
+            ),
+            child: SegmentedButton<bool>(
+              segments: const [
+                ButtonSegment(value: false, label: Text('Entries')),
+                ButtonSegment(value: true, label: Text('Tasks')),
+              ],
+              selected: {_showTasks},
+              onSelectionChanged: (s) => setState(() => _showTasks = s.first),
+            ),
+          ),
+          Expanded(child: _showTasks ? _tasksTab() : _entriesTab()),
+        ],
+      ),
+    );
+  }
+
+  Widget _entriesTab() {
+    final entriesAsync = ref.watch(labEntriesProvider(_key));
+    return entriesAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('Failed to load Lab: $e')),
+      data: (entries) {
+        _migrateNotesIfNeeded(entries);
+        final visible = _typeFilter == null
+            ? entries
+            : entries.where((e) => e.type == _typeFilter).toList();
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _quickAddRow(),
+            if (entries.isNotEmpty) _filterRow(),
+            Expanded(
+              child: visible.isEmpty
+                  ? EmptyState(
+                      icon: Icons.science_outlined,
+                      message: entries.isEmpty
+                          ? 'The story of this song starts here'
+                          : 'Nothing of this type yet',
+                      hint: entries.isEmpty
+                          ? 'Capture ideas, decisions ("why we play it '
+                                'this way"), experiments and problems — '
+                                'so the band never loses the context.'
+                          : null,
+                    )
+                  : ListView.builder(
+                      padding: const EdgeInsets.only(bottom: 96),
+                      itemCount: visible.length,
+                      itemBuilder: (context, i) => _entryCard(visible[i]),
+                    ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  // ---- Tasks tab (#68) ----
+
+  Widget _tasksTab() {
+    final tasksAsync = ref.watch(labTasksProvider(_key));
+    return tasksAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('Failed to load tasks: $e')),
+      data: (tasks) {
+        final open = tasks.where((t) => t.isOpen).toList();
+        final closed = tasks.where((t) => !t.isOpen).toList();
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(MonoPulseSpacing.md),
+              child: ActionChip(
+                avatar: const Icon(Icons.add, size: 18),
+                label: const Text('Add task'),
+                onPressed: _composeTask,
               ),
-            ],
+            ),
+            Expanded(
+              child: tasks.isEmpty
+                  ? const EmptyState(
+                      icon: Icons.check_circle_outline,
+                      message: 'No homework yet',
+                      hint:
+                          'Tasks are song-scoped: "learn the solo", '
+                          '"transcribe the bridge" — so everyone knows what '
+                          'to prepare.',
+                    )
+                  : ListView(
+                      padding: const EdgeInsets.only(bottom: 96),
+                      children: [
+                        for (final t in open) _taskCard(t),
+                        if (closed.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.all(MonoPulseSpacing.md),
+                            child: Text(
+                              'Done',
+                              style: MonoPulseTypography.bodySmall.copyWith(
+                                color: MonoPulseColors.textSecondary,
+                              ),
+                            ),
+                          ),
+                        for (final t in closed) _taskCard(t),
+                      ],
+                    ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  static const _statusOrder = [
+    SongTaskStatus.todo,
+    SongTaskStatus.doing,
+    SongTaskStatus.done,
+    SongTaskStatus.blocked,
+    SongTaskStatus.skipped,
+  ];
+
+  Future<void> _cycleStatus(SongTask task) {
+    final next =
+        _statusOrder[(_statusOrder.indexOf(task.status) + 1) %
+            _statusOrder.length];
+    return ref
+        .read(labRepositoryProvider)
+        .saveTask(task.copyWith(status: next), bandId: widget.bandId);
+  }
+
+  Widget _taskCard(SongTask t) {
+    return Card(
+      margin: const EdgeInsets.symmetric(
+        horizontal: MonoPulseSpacing.lg,
+        vertical: MonoPulseSpacing.xs,
+      ),
+      child: ListTile(
+        dense: true,
+        title: Text(
+          t.title,
+          style: t.isOpen
+              ? null
+              : const TextStyle(
+                  decoration: TextDecoration.lineThrough,
+                  color: MonoPulseColors.textSecondary,
+                ),
+        ),
+        subtitle: Text(
+          [
+            if (t.assignedToUserId != null) _memberName(t.assignedToUserId!),
+            if (t.dueAt != null) 'due ${t.dueAt!.day}/${t.dueAt!.month}',
+          ].join(' · '),
+        ),
+        // Tap the chip to cycle the status; long-press the row deletes.
+        trailing: ActionChip(
+          label: Text(t.status.name),
+          onPressed: () => _cycleStatus(t),
+        ),
+        onLongPress: () async {
+          final repo = ref.read(labRepositoryProvider);
+          await repo.deleteTask(widget.song.id, t.id, bandId: widget.bandId);
+          if (!mounted) return;
+          showAppSnackBar(
+            context,
+            'Task deleted',
+            actionLabel: 'Undo',
+            onAction: () => repo.saveTask(t, bandId: widget.bandId),
           );
         },
       ),
     );
+  }
+
+  String _memberName(String uid) {
+    final bands = ref.read(bandsProvider).value ?? [];
+    for (final band in bands) {
+      for (final m in band.members) {
+        if (m.uid == uid) {
+          return memberLabel(displayName: m.displayName, email: m.email);
+        }
+      }
+    }
+    return 'Member';
+  }
+
+  Future<void> _composeTask() async {
+    final band = widget.bandId == null
+        ? null
+        : (ref.read(bandsProvider).value ?? [])
+              .where((b) => b.id == widget.bandId)
+              .firstOrNull;
+    final result = await showModalBottomSheet<SongTask>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => _ComposeTaskSheet(
+        songId: widget.song.id,
+        bandId: widget.bandId,
+        members: band?.members ?? const [],
+      ),
+    );
+    if (result == null || !mounted) return;
+    await ref
+        .read(labRepositoryProvider)
+        .saveTask(result, bandId: widget.bandId);
   }
 
   Widget _quickAddRow() => Padding(
@@ -235,8 +410,7 @@ class _SongLabScreenState extends ConsumerState<SongLabScreen> {
             AppFilterChip(
               label: _typeLabel(t),
               selected: _typeFilter == t,
-              onSelected: (sel) =>
-                  setState(() => _typeFilter = sel ? t : null),
+              onSelected: (sel) => setState(() => _typeFilter = sel ? t : null),
             ),
             const SizedBox(width: MonoPulseSpacing.sm),
           ],
@@ -398,8 +572,7 @@ class _ComposeEntrySheetState extends State<_ComposeEntrySheet> {
                 border: OutlineInputBorder(),
               ),
             ),
-            if (widget.song.sections.isNotEmpty &&
-                widget.existing == null) ...[
+            if (widget.song.sections.isNotEmpty && widget.existing == null) ...[
               const SizedBox(height: MonoPulseSpacing.md),
               DropdownButtonFormField<String?>(
                 initialValue: _sectionId,
@@ -408,7 +581,7 @@ class _ComposeEntrySheetState extends State<_ComposeEntrySheet> {
                   border: OutlineInputBorder(),
                 ),
                 items: [
-                  const DropdownMenuItem(value: null, child: Text('—')),
+                  const DropdownMenuItem(child: Text('—')),
                   for (final s in widget.song.sections)
                     DropdownMenuItem(value: s.id, child: Text(s.name)),
                 ],
@@ -434,6 +607,141 @@ class _ComposeEntrySheetState extends State<_ComposeEntrySheet> {
                     ),
                   ),
                   child: const Text('Save'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Add-task sheet (#68): title, optional due date, optional assignee (band
+/// songs only — members come from the band).
+class _ComposeTaskSheet extends StatefulWidget {
+  const _ComposeTaskSheet({
+    required this.songId,
+    required this.bandId,
+    required this.members,
+  });
+
+  final String songId;
+  final String? bandId;
+  final List<BandMember> members;
+
+  @override
+  State<_ComposeTaskSheet> createState() => _ComposeTaskSheetState();
+}
+
+class _ComposeTaskSheetState extends State<_ComposeTaskSheet> {
+  static const _uuid = Uuid();
+  final _title = TextEditingController();
+  DateTime? _dueAt;
+  String? _assignee;
+
+  @override
+  void dispose() {
+    _title.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('New task', style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: MonoPulseSpacing.md),
+            TextField(
+              controller: _title,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'What needs to be prepared?',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    icon: const Icon(Icons.event, size: 18),
+                    label: Text(
+                      _dueAt == null
+                          ? 'Due date (optional)'
+                          : 'Due ${_dueAt!.day}/${_dueAt!.month}',
+                    ),
+                    onPressed: () async {
+                      final picked = await showDatePicker(
+                        context: context,
+                        initialDate: DateTime.now(),
+                        firstDate: DateTime.now(),
+                        lastDate: DateTime.now().add(const Duration(days: 365)),
+                      );
+                      if (picked != null) setState(() => _dueAt = picked);
+                    },
+                  ),
+                ),
+              ],
+            ),
+            if (widget.members.isNotEmpty) ...[
+              const SizedBox(height: MonoPulseSpacing.md),
+              DropdownButtonFormField<String?>(
+                initialValue: _assignee,
+                decoration: const InputDecoration(
+                  labelText: 'Assignee (optional)',
+                  border: OutlineInputBorder(),
+                ),
+                items: [
+                  const DropdownMenuItem(child: Text('—')),
+                  for (final m in widget.members)
+                    DropdownMenuItem(
+                      value: m.uid,
+                      child: Text(
+                        memberLabel(displayName: m.displayName, email: m.email),
+                      ),
+                    ),
+                ],
+                onChanged: (v) => setState(() => _assignee = v),
+              ),
+            ],
+            const SizedBox(height: MonoPulseSpacing.lg),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Cancel'),
+                ),
+                const SizedBox(width: MonoPulseSpacing.sm),
+                ElevatedButton(
+                  onPressed: () {
+                    final title = _title.text.trim();
+                    if (title.isEmpty) return;
+                    final now = DateTime.now();
+                    Navigator.pop(
+                      context,
+                      SongTask(
+                        id: _uuid.v4(),
+                        songId: widget.songId,
+                        bandId: widget.bandId,
+                        title: title,
+                        assignedToUserId: _assignee,
+                        dueAt: _dueAt,
+                        createdAt: now,
+                        updatedAt: now,
+                      ),
+                    );
+                  },
+                  child: const Text('Add'),
                 ),
               ],
             ),

--- a/test/screens/songs/song_lab_screen_test.dart
+++ b/test/screens/songs/song_lab_screen_test.dart
@@ -19,14 +19,36 @@ class _InMemoryLabRepo extends FirestoreLabRepository {
     : super(firestore: MockFirebaseFirestore(), auth: MockFirebaseAuth());
 
   final entries = <SongLabEntry>[];
+  final tasks = <SongTask>[];
   final _controller = StreamController<List<SongLabEntry>>.broadcast();
+  final _taskController = StreamController<List<SongTask>>.broadcast();
 
   void _emit() => _controller.add(List.of(entries));
+  void _emitTasks() => _taskController.add(List.of(tasks));
 
   @override
   Stream<List<SongLabEntry>> watchEntries(String songId, {String? bandId}) {
     scheduleMicrotask(_emit);
     return _controller.stream;
+  }
+
+  @override
+  Stream<List<SongTask>> watchTasks(String songId, {String? bandId}) {
+    scheduleMicrotask(_emitTasks);
+    return _taskController.stream;
+  }
+
+  @override
+  Future<void> saveTask(SongTask task, {String? bandId}) async {
+    tasks.removeWhere((t) => t.id == task.id);
+    tasks.insert(0, task);
+    _emitTasks();
+  }
+
+  @override
+  Future<void> deleteTask(String songId, String taskId, {String? bandId}) async {
+    tasks.removeWhere((t) => t.id == taskId);
+    _emitTasks();
   }
 
   @override
@@ -125,6 +147,35 @@ void main() {
 
       expect(repo.entries.single.status, 'active');
       expect(repo.entries.single.type, LabEntryType.decision);
+    });
+
+    testWidgets('tasks tab: add task via sheet and cycle status (#68)', (
+      tester,
+    ) async {
+      final repo = await pump(tester);
+
+      await tester.tap(find.text('Tasks'));
+      await tester.pumpAndSettle();
+      expect(find.text('No homework yet'), findsOneWidget);
+
+      await tester.tap(find.text('Add task'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'What needs to be prepared?'),
+        'Learn the solo',
+      );
+      await tester.tap(find.text('Add'));
+      await tester.pumpAndSettle();
+
+      expect(repo.tasks, hasLength(1));
+      expect(repo.tasks.single.title, 'Learn the solo');
+      expect(repo.tasks.single.status, SongTaskStatus.todo);
+      expect(find.text('Learn the solo'), findsOneWidget);
+
+      // Cycle todo → doing via the status chip.
+      await tester.tap(find.text('todo'));
+      await tester.pumpAndSettle();
+      expect(repo.tasks.single.status, SongTaskStatus.doing);
     });
 
     testWidgets('migrates song.notes into the first entry', (tester) async {


### PR DESCRIPTION
Closes #68 (manual close after merge).

Completes the Song Lab tasks story — the Practice screen's cross-song homework list shipped in #134; this adds the Lab side:

- **Lab screen** gains an `Entries | Tasks` segmented view. Tasks: quick add-task sheet (title, optional due date, optional assignee from band members via `memberLabel`), tap the status chip to cycle todo → doing → done → blocked → skipped, closed tasks fold under a "Done" divider, long-press deletes with Undo.
- **Rehearsal detail**: on the confirmed card, each setlist song line appends "N open tasks" (`openTaskCountProvider`, one-shot Firestore count) — the "3 unfinished tasks for this song" view from the issue.
- Song-scoped by design — not a general task manager (epic guardrail).

Tests: tasks-tab widget test (add via sheet, status cycle) on the in-memory repo. Full suite green (1992), analyze 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)