### PR TITLE
feat(lab): version snapshots + Markdown export (#70)

### DIFF
--- a/lib/screens/songs/song_lab_screen.dart
+++ b/lib/screens/songs/song_lab_screen.dart
@@ -10,10 +10,13 @@ import '../../models/song_lab.dart';
 import '../../providers/auth/auth_provider.dart';
 import '../../providers/data/data_providers.dart';
 import '../../services/analytics_service.dart';
+import '../../services/export/lab_markdown.dart';
 import '../../theme/mono_pulse_theme.dart';
+import '../../utils/chordpro.dart';
 import '../../utils/member_label.dart';
 import '../../utils/snackbar.dart';
 import '../../widgets/app_filter_chip.dart';
+import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/standard_screen_scaffold.dart';
 
@@ -154,10 +157,93 @@ class _SongLabScreenState extends ConsumerState<SongLabScreen> {
       .read(labRepositoryProvider)
       .saveEntry(entry.copyWith(status: status), bandId: widget.bandId);
 
+  // ---- Versions (#70) ----
+
+  Future<void> _saveVersion() async {
+    final result = await showModalBottomSheet<(String, String?, bool)>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const _SaveVersionSheet(),
+    );
+    if (result == null || !mounted) return;
+    final (name, notes, makeCurrent) = result;
+
+    final repo = ref.read(labRepositoryProvider);
+    final now = DateTime.now();
+    final version = SongVersion(
+      id: _uuid.v4(),
+      songId: widget.song.id,
+      bandId: widget.bandId,
+      name: name,
+      status: makeCurrent ? 'current' : 'archived',
+      bpm: widget.song.ourBPM,
+      key: widget.song.ourKey,
+      structureSnapshot: songMapSummary(
+        widget.song.sections.map((s) => s.name).toList(),
+      ),
+      lyricsSnapshot: songToChordPro(widget.song),
+      notes: notes,
+      createdAt: now,
+    );
+    await repo.saveVersion(version, bandId: widget.bandId);
+    if (makeCurrent) {
+      await repo.setCurrentVersion(
+        widget.song.id,
+        version.id,
+        bandId: widget.bandId,
+      );
+    }
+    // The changelog lives in the timeline (never silently overwritten).
+    final uid = ref.read(firebaseAuthProvider).currentUser?.uid ?? '';
+    await repo.saveEntry(
+      SongLabEntry(
+        id: _uuid.v4(),
+        songId: widget.song.id,
+        bandId: widget.bandId,
+        type: LabEntryType.versionChange,
+        title: 'Version: $name',
+        body: notes,
+        versionId: version.id,
+        authorId: uid,
+        createdAt: now,
+        updatedAt: now,
+      ),
+      bandId: widget.bandId,
+    );
+    if (!mounted) return;
+    showAppSnackBar(context, 'Version "$name" saved');
+  }
+
+  Future<void> _exportMarkdown() async {
+    final entries = await ref.read(labEntriesProvider(_key).future);
+    final tasks = await ref.read(labTasksProvider(_key).future);
+    final versions = await ref.read(labVersionsProvider(_key).future);
+    final md = buildLabMarkdown(
+      song: widget.song,
+      entries: entries,
+      tasks: tasks,
+      versions: versions,
+    );
+    final ok = await shareLabMarkdown(md, widget.song.title);
+    if (!ok && mounted) showAppSnackBar(context, 'Export failed');
+  }
+
   @override
   Widget build(BuildContext context) {
     return StandardScreenScaffold(
       title: 'Lab — ${widget.song.title}',
+      menuItems: [
+        AppMenuItem(
+          icon: Icons.bookmark_add_outlined,
+          label: 'Save version',
+          onTap: _saveVersion,
+        ),
+        AppMenuItem(
+          icon: Icons.description_outlined,
+          label: 'Export history (Markdown)',
+          onTap: _exportMarkdown,
+        ),
+      ],
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
@@ -742,6 +828,100 @@ class _ComposeTaskSheetState extends State<_ComposeTaskSheet> {
                     );
                   },
                   child: const Text('Add'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Save-version sheet (#70): name, optional notes, mark-current flag.
+class _SaveVersionSheet extends StatefulWidget {
+  const _SaveVersionSheet();
+
+  @override
+  State<_SaveVersionSheet> createState() => _SaveVersionSheetState();
+}
+
+class _SaveVersionSheetState extends State<_SaveVersionSheet> {
+  final _name = TextEditingController();
+  final _notes = TextEditingController();
+  bool _makeCurrent = true;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _notes.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Save version', style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 4),
+            Text(
+              'A named snapshot of the song as it is right now — key, BPM, '
+              'structure and the full chord chart.',
+              style: MonoPulseTypography.bodySmall.copyWith(
+                color: MonoPulseColors.textSecondary,
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            TextField(
+              controller: _name,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'Name (e.g. v0.3, Live, Acoustic)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            TextField(
+              controller: _notes,
+              maxLines: 2,
+              decoration: const InputDecoration(
+                labelText: 'What changed? (optional)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Mark as current version'),
+              value: _makeCurrent,
+              onChanged: (v) => setState(() => _makeCurrent = v),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Cancel'),
+                ),
+                const SizedBox(width: MonoPulseSpacing.sm),
+                ElevatedButton(
+                  onPressed: () {
+                    final name = _name.text.trim();
+                    if (name.isEmpty) return;
+                    Navigator.pop(context, (
+                      name,
+                      _notes.text.trim().isEmpty ? null : _notes.text.trim(),
+                      _makeCurrent,
+                    ));
+                  },
+                  child: const Text('Save'),
                 ),
               ],
             ),

--- a/lib/services/export/lab_markdown.dart
+++ b/lib/services/export/lab_markdown.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../models/song.dart';
+import '../../models/song_lab.dart';
+
+/// Markdown export of a song's Lab history (#70): active decisions, open
+/// tasks, versions and the timeline — the "how we play it and why" document.
+String buildLabMarkdown({
+  required Song song,
+  required List<SongLabEntry> entries,
+  required List<SongTask> tasks,
+  required List<SongVersion> versions,
+}) {
+  final b = StringBuffer()
+    ..writeln('# ${song.title} — Lab history')
+    ..writeln()
+    ..writeln('${song.artist} · exported ${_d(DateTime.now())}')
+    ..writeln();
+
+  final decisions = entries
+      .where((e) => e.type == LabEntryType.decision && e.status == 'active')
+      .toList();
+  if (decisions.isNotEmpty) {
+    b.writeln('## Active decisions');
+    for (final e in decisions) {
+      b.writeln('- **${e.title ?? 'Decision'}**'
+          '${e.body != null ? ' — ${e.body}' : ''}');
+    }
+    b.writeln();
+  }
+
+  final open = tasks.where((t) => t.isOpen).toList();
+  if (open.isNotEmpty) {
+    b.writeln('## Open tasks');
+    for (final t in open) {
+      b.writeln('- [ ] ${t.title}'
+          '${t.dueAt != null ? ' (due ${_d(t.dueAt!)})' : ''}');
+    }
+    b.writeln();
+  }
+
+  if (versions.isNotEmpty) {
+    b.writeln('## Versions');
+    for (final v in versions) {
+      b.writeln('- **${v.name}**${v.isCurrent ? ' — current' : ''}'
+          '${v.key != null ? ' · ${v.key}' : ''}'
+          '${v.bpm != null ? ' · ${v.bpm} BPM' : ''}'
+          ' · ${_d(v.createdAt)}'
+          '${v.notes != null ? ' — ${v.notes}' : ''}');
+    }
+    b.writeln();
+  }
+
+  if (entries.isNotEmpty) {
+    b.writeln('## Timeline');
+    for (final e in entries) {
+      b.writeln('- ${_d(e.createdAt)} · ${e.type.name}'
+          '${e.status != null ? ' (${e.status})' : ''}: '
+          '${e.title ?? ''}${e.title != null && e.body != null ? ' — ' : ''}'
+          '${e.body ?? ''}');
+    }
+  }
+  return b.toString();
+}
+
+String _d(DateTime t) => '${t.year}-${t.month.toString().padLeft(2, '0')}-'
+    '${t.day.toString().padLeft(2, '0')}';
+
+/// Shares the Lab history as a `.md` file (same share path as ChordPro/CSV).
+Future<bool> shareLabMarkdown(String markdown, String songTitle) async {
+  try {
+    final safe = songTitle.trim().replaceAll(RegExp(r'[^\w\s-]'), '').trim();
+    final fileName = '${safe.isEmpty ? 'song' : safe}_lab.md';
+    await SharePlus.instance.share(
+      ShareParams(
+        files: [
+          XFile.fromData(
+            utf8.encode(markdown),
+            name: fileName,
+            mimeType: 'text/markdown',
+          ),
+        ],
+        fileNameOverrides: [fileName],
+        subject: 'FlowGroove Lab — $songTitle',
+      ),
+    );
+    return true;
+  } catch (e, stackTrace) {
+    debugPrint('Lab markdown share failed: $e\n$stackTrace');
+    return false;
+  }
+}

--- a/test/services/lab_markdown_test.dart
+++ b/test/services/lab_markdown_test.dart
@@ -1,0 +1,108 @@
+import 'package:flowgroove/models/song.dart';
+import 'package:flowgroove/models/song_lab.dart';
+import 'package:flowgroove/services/export/lab_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final song = Song(
+    id: 's1',
+    title: 'Hey Joe',
+    artist: 'Jimi Hendrix',
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
+
+  SongLabEntry entry(
+    LabEntryType type, {
+    String? title,
+    String? body,
+    String? status,
+  }) => SongLabEntry(
+    id: '${type.name}-${title ?? ''}',
+    songId: 's1',
+    type: type,
+    title: title,
+    body: body,
+    status: status,
+    authorId: 'u1',
+    createdAt: DateTime(2026, 7, 10),
+    updatedAt: DateTime(2026, 7, 10),
+  );
+
+  test('buildLabMarkdown assembles all sections (#70)', () {
+    final md = buildLabMarkdown(
+      song: song,
+      entries: [
+        entry(
+          LabEntryType.decision,
+          title: 'Half-time chorus',
+          body: 'last chorus half-time',
+          status: 'active',
+        ),
+        entry(
+          LabEntryType.decision,
+          title: 'Old idea',
+          status: 'superseded',
+        ),
+        entry(LabEntryType.note, body: 'riff idea'),
+      ],
+      tasks: [
+        SongTask(
+          id: 't1',
+          songId: 's1',
+          title: 'Learn the solo',
+          dueAt: DateTime(2026, 8, 1),
+          createdAt: DateTime(2026, 7, 1),
+          updatedAt: DateTime(2026, 7, 1),
+        ),
+        SongTask(
+          id: 't2',
+          songId: 's1',
+          title: 'Done thing',
+          status: SongTaskStatus.done,
+          createdAt: DateTime(2026, 7, 1),
+          updatedAt: DateTime(2026, 7, 1),
+        ),
+      ],
+      versions: [
+        SongVersion(
+          id: 'v1',
+          songId: 's1',
+          name: 'v0.3 Acoustic',
+          status: 'current',
+          key: 'Em',
+          bpm: 82,
+          createdAt: DateTime(2026, 7, 12),
+        ),
+      ],
+    );
+
+    expect(md, contains('# Hey Joe — Lab history'));
+    expect(md, contains('## Active decisions'));
+    expect(md, contains('**Half-time chorus** — last chorus half-time'));
+    // Superseded decisions stay out of Active decisions (but remain in the
+    // timeline below).
+    final beforeTimeline = md.split('## Timeline').first;
+    expect(beforeTimeline, isNot(contains('Old idea')));
+    expect(md.split('## Timeline').last, contains('Old idea'));
+    expect(md, contains('## Open tasks'));
+    expect(md, contains('- [ ] Learn the solo (due 2026-08-01)'));
+    expect(md, isNot(contains('- [ ] Done thing')));
+    expect(md, contains('## Versions'));
+    expect(md, contains('**v0.3 Acoustic** — current · Em · 82 BPM'));
+    expect(md, contains('## Timeline'));
+    expect(md, contains('riff idea'));
+  });
+
+  test('empty lab still produces a valid header-only document', () {
+    final md = buildLabMarkdown(
+      song: song,
+      entries: const [],
+      tasks: const [],
+      versions: const [],
+    );
+    expect(md, contains('# Hey Joe — Lab history'));
+    expect(md, isNot(contains('## Active decisions')));
+    expect(md, isNot(contains('## Timeline')));
+  });
+}


### PR DESCRIPTION
Closes #70 (manual close after merge). Stacked on #135.

- **Save version** (Lab ⋮ menu): sheet with name / what-changed notes / mark-current switch → `SongVersion` snapshotting key, BPM, structure summary and the **full ChordPro chart** (`songToChordPro` — reused, no new format). Mark-current archives every other version in one batch. Each save appends a `versionChange` timeline entry — the visible changelog.
- **Export history (Markdown)** (Lab ⋮ menu): `# Song — Lab history` with Active decisions / Open tasks (checkboxes + due dates) / Versions (current flag, key, BPM) / full Timeline; shared as a `.md` file through the same share path as ChordPro/CSV.
- Deliberately no diff/compare (spec: "musicians just need which version is current and what changed").

Tests: markdown builder unit tests (sections, superseded-decision exclusion, empty lab) — suite green (1994), analyze 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)