### PR TITLE
feat(lab): audio recordings (#69)

### DIFF
--- a/lib/screens/songs/components/lab_recording_sheet.dart
+++ b/lib/screens/songs/components/lab_recording_sheet.dart
@@ -1,0 +1,301 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:record/record.dart';
+
+import '../../../theme/mono_pulse_theme.dart';
+
+/// Result of the recording sheet (#69): audio bytes + metadata for upload.
+class LabRecordingResult {
+  LabRecordingResult({
+    required this.bytes,
+    required this.ext,
+    this.title,
+    this.notes,
+  });
+
+  final Uint8List bytes;
+  final String ext;
+  final String? title;
+  final String? notes;
+}
+
+/// Capture-or-attach sheet for Song Lab audio ideas (#69). Capture, don't
+/// edit: record / pick a file, name it, add manual timestamp notes
+/// ("00:42 good chorus entry"). No waveform, no DAW — by design.
+class LabRecordingSheet extends StatefulWidget {
+  const LabRecordingSheet({super.key});
+
+  @override
+  State<LabRecordingSheet> createState() => _LabRecordingSheetState();
+}
+
+class _LabRecordingSheetState extends State<LabRecordingSheet> {
+  final _title = TextEditingController();
+  final _notes = TextEditingController();
+  final _recorder = AudioRecorder();
+
+  bool _recording = false;
+  int _elapsed = 0;
+  Timer? _ticker;
+  Uint8List? _bytes;
+  String _ext = 'm4a';
+  String? _pickedName;
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    _recorder.dispose();
+    _title.dispose();
+    _notes.dispose();
+    super.dispose();
+  }
+
+  Future<void> _toggleRecord() async {
+    if (_recording) {
+      final path = await _recorder.stop();
+      _ticker?.cancel();
+      if (path != null) {
+        final bytes = await File(path).readAsBytes();
+        setState(() {
+          _bytes = bytes;
+          _ext = 'm4a';
+          _pickedName = null;
+          _recording = false;
+        });
+      } else {
+        setState(() => _recording = false);
+      }
+      return;
+    }
+    if (!await _recorder.hasPermission()) return;
+    final dir = await getTemporaryDirectory();
+    final path =
+        '${dir.path}/lab_rec_${DateTime.now().millisecondsSinceEpoch}.m4a';
+    await _recorder.start(
+      const RecordConfig(),
+      path: path,
+    );
+    _elapsed = 0;
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() => _elapsed++);
+    });
+    setState(() {
+      _recording = true;
+      _bytes = null;
+    });
+  }
+
+  Future<void> _pickFile() async {
+    final file = await FilePicker.pickFile(type: FileType.audio);
+    if (file == null) return;
+    final bytes = await file.readAsBytes();
+    setState(() {
+      _bytes = bytes;
+      _ext = (file.extension ?? 'm4a').toLowerCase();
+      _pickedName = file.name;
+      _recording = false;
+    });
+    if (_title.text.isEmpty && file.name.isNotEmpty) {
+      _title.text = file.name.replaceAll(RegExp(r'\.\w+$'), '');
+    }
+  }
+
+  String get _statusLine {
+    if (_recording) {
+      final m = (_elapsed ~/ 60).toString().padLeft(2, '0');
+      final s = (_elapsed % 60).toString().padLeft(2, '0');
+      return 'Recording… $m:$s';
+    }
+    if (_bytes != null) {
+      final mb = (_bytes!.length / (1024 * 1024)).toStringAsFixed(1);
+      return _pickedName != null
+          ? '$_pickedName · ${mb}MB'
+          : 'Recording ready · ${mb}MB';
+    }
+    return kIsWeb
+        ? 'Attach an audio file (recording: use the mobile app)'
+        : 'Record an idea or attach a file';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final canSave = _bytes != null && !_recording;
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Audio idea',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              _statusLine,
+              style: MonoPulseTypography.bodySmall.copyWith(
+                color: _recording
+                    ? MonoPulseColors.accentOrange
+                    : MonoPulseColors.textSecondary,
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            Row(
+              children: [
+                if (!kIsWeb)
+                  Expanded(
+                    child: FilledButton.tonalIcon(
+                      onPressed: _toggleRecord,
+                      icon: Icon(_recording ? Icons.stop : Icons.mic),
+                      label: Text(_recording ? 'Stop' : 'Record'),
+                    ),
+                  ),
+                if (!kIsWeb) const SizedBox(width: MonoPulseSpacing.md),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _recording ? null : _pickFile,
+                    icon: const Icon(Icons.attach_file),
+                    label: const Text('Attach file'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            TextField(
+              controller: _title,
+              decoration: const InputDecoration(
+                labelText: 'Title (e.g. "Bridge riff idea")',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            TextField(
+              controller: _notes,
+              maxLines: 3,
+              decoration: const InputDecoration(
+                labelText: 'Timestamp notes (optional)',
+                hintText: '00:42 good chorus entry\n01:15 tempo drops',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.lg),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Cancel'),
+                ),
+                const SizedBox(width: MonoPulseSpacing.sm),
+                ElevatedButton(
+                  onPressed: canSave
+                      ? () => Navigator.pop(
+                          context,
+                          LabRecordingResult(
+                            bytes: _bytes!,
+                            ext: _ext,
+                            title: _title.text.trim().isEmpty
+                                ? null
+                                : _title.text.trim(),
+                            notes: _notes.text.trim().isEmpty
+                                ? null
+                                : _notes.text.trim(),
+                          ),
+                        )
+                      : null,
+                  child: const Text('Save'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Minimal play/pause for a recording entry — capture, don't edit (#69).
+class LabAudioPlayer extends StatefulWidget {
+  const LabAudioPlayer({required this.url, super.key});
+
+  final String url;
+
+  @override
+  State<LabAudioPlayer> createState() => _LabAudioPlayerState();
+}
+
+class _LabAudioPlayerState extends State<LabAudioPlayer> {
+  final _player = AudioPlayer();
+  bool _loaded = false;
+
+  @override
+  void dispose() {
+    _player.dispose();
+    super.dispose();
+  }
+
+  Future<void> _toggle() async {
+    if (_player.playing) {
+      await _player.pause();
+      return;
+    }
+    if (!_loaded) {
+      await _player.setUrl(widget.url);
+      _loaded = true;
+    }
+    if (_player.processingState == ProcessingState.completed) {
+      await _player.seek(Duration.zero);
+    }
+    unawaited(_player.play());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<PlayerState>(
+      stream: _player.playerStateStream,
+      builder: (context, snapshot) {
+        final playing = snapshot.data?.playing ?? false;
+        final done =
+            snapshot.data?.processingState == ProcessingState.completed;
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              visualDensity: VisualDensity.compact,
+              icon: Icon(
+                playing && !done ? Icons.pause_circle : Icons.play_circle,
+                color: MonoPulseColors.accentOrange,
+              ),
+              onPressed: _toggle,
+            ),
+            StreamBuilder<Duration>(
+              stream: _player.positionStream,
+              builder: (context, pos) {
+                final p = pos.data ?? Duration.zero;
+                final total = _player.duration ?? Duration.zero;
+                String f(Duration d) =>
+                    '${d.inMinutes}:${(d.inSeconds % 60).toString().padLeft(2, '0')}';
+                return Text(
+                  _loaded ? '${f(p)} / ${f(total)}' : 'Play',
+                  style: MonoPulseTypography.bodySmall.copyWith(
+                    color: MonoPulseColors.textSecondary,
+                  ),
+                );
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/songs/song_lab_screen.dart
+++ b/lib/screens/songs/song_lab_screen.dart
@@ -11,6 +11,7 @@ import '../../providers/auth/auth_provider.dart';
 import '../../providers/data/data_providers.dart';
 import '../../services/analytics_service.dart';
 import '../../services/export/lab_markdown.dart';
+import '../../services/storage_service.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/chordpro.dart';
 import '../../utils/member_label.dart';
@@ -19,6 +20,7 @@ import '../../widgets/app_filter_chip.dart';
 import '../../widgets/app_menu_sheet.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/standard_screen_scaffold.dart';
+import 'components/lab_recording_sheet.dart';
 
 /// Song Lab timeline (#67): a reverse-chronological journal of typed entries
 /// for one song — the history of "our version" (notes, decisions,
@@ -473,9 +475,61 @@ class _SongLabScreenState extends ConsumerState<SongLabScreen> {
             label: Text('+ ${_typeLabel(t)}'),
             onPressed: () => _compose(t),
           ),
+        ActionChip(
+          avatar: Icon(_typeIcons[LabEntryType.recording], size: 18),
+          label: const Text('+ Recording'),
+          onPressed: _composeRecording,
+        ),
       ],
     ),
   );
+
+  /// Record/attach an audio idea (#69): upload to Storage, then a
+  /// `recording` entry with the download URL as its attachment.
+  Future<void> _composeRecording() async {
+    final result = await showModalBottomSheet<LabRecordingResult>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const LabRecordingSheet(),
+    );
+    if (result == null || !mounted) return;
+
+    final entryId = _uuid.v4();
+    try {
+      final url = await StorageService().uploadLabAudio(
+        result.bytes,
+        bandId: widget.bandId,
+        songId: widget.song.id,
+        entryId: entryId,
+        ext: result.ext,
+      );
+      final uid = ref.read(firebaseAuthProvider).currentUser?.uid ?? '';
+      final now = DateTime.now();
+      await ref
+          .read(labRepositoryProvider)
+          .saveEntry(
+            SongLabEntry(
+              id: entryId,
+              songId: widget.song.id,
+              bandId: widget.bandId,
+              type: LabEntryType.recording,
+              title: result.title,
+              body: result.notes,
+              authorId: uid,
+              createdAt: now,
+              updatedAt: now,
+              attachmentIds: [url],
+            ),
+            bandId: widget.bandId,
+          );
+      unawaited(
+        AnalyticsService.logLabEntryAdded(type: LabEntryType.recording.name),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      showAppSnackBar(context, 'Upload failed: $e');
+    }
+  }
 
   Widget _filterRow() => Padding(
     padding: const EdgeInsets.symmetric(
@@ -540,6 +594,8 @@ class _SongLabScreenState extends ConsumerState<SongLabScreen> {
           children: [
             if (e.body?.isNotEmpty == true)
               Text(e.body!, maxLines: 4, overflow: TextOverflow.ellipsis),
+            if (e.type == LabEntryType.recording && e.attachmentIds.isNotEmpty)
+              LabAudioPlayer(url: e.attachmentIds.first),
             Text(
               [
                 _typeLabel(e.type),

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -55,6 +55,30 @@ class StorageService {
   /// Returns the download URL of the uploaded file.
   ///
   /// Throws [ApiError] if upload fails or user is not authenticated.
+  /// Uploads a Song Lab audio idea (#69) and returns its download URL.
+  /// Path: lab_audio/{user|band}/{ownerId}/{songId}/{entryId}.{ext} — matches
+  /// storage.rules. 25MB is enforced client-side AND in the rules.
+  Future<String> uploadLabAudio(
+    Uint8List bytes, {
+    required String? bandId,
+    required String songId,
+    required String entryId,
+    String ext = 'm4a',
+    String contentType = 'audio/mp4',
+  }) async {
+    _requireAuth();
+    if (bytes.length >= 25 * 1024 * 1024) {
+      throw Exception('Recording is larger than 25MB');
+    }
+    final owner = bandId == null ? 'user/$_currentUserId' : 'band/$bandId';
+    final ref = _storage.ref().child('lab_audio/$owner/$songId/$entryId.$ext');
+    final snapshot = await ref.putData(
+      bytes,
+      SettableMetadata(contentType: contentType),
+    );
+    return snapshot.ref.getDownloadURL();
+  }
+
   Future<String> uploadProfilePicture(Uint8List bytes) async {
     try {
       _requireAuth();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  audio_session:
+    dependency: transitive
+    description:
+      name: audio_session
+      sha256: f9e7711a0e24ca8b40f5d7ac374c3c6e55016f3157912badd18199cdbbca5c4d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
   barcode:
     dependency: transitive
     description:
@@ -927,6 +935,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.14.0"
+  just_audio:
+    dependency: "direct main"
+    description:
+      name: just_audio
+      sha256: e60aa97b233ddea025e13dfac59195207f528fa5e9e4a4a49a8c0766701e5fe6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.6"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      sha256: "2532c8d6702528824445921c5ff10548b518b13f808c2e34c2fd54793b999a6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      sha256: "6ba8a2a7e87d57d32f0f7b42856ade3d6a9fbe0f1a11fabae0a4f00bb73f0663"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.16"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   # Audio
   flutter_soloud: ^4.0.9
   record: ^7.1.0
+  just_audio: ^0.10.0
 
   # PDF & Export
   pdf: ^3.11.2

--- a/storage.rules
+++ b/storage.rules
@@ -22,6 +22,25 @@ service firebase.storage {
       allow write, delete: if false;
     }
 
+    // Song Lab audio ideas (#69): lab_audio/{ownerType}/{ownerId}/{songId}/{file}.
+    // Personal path is owner-locked. Band path mirrors band_avatars: reads for
+    // any signed-in user (URLs carry unguessable ids); writes are size-capped
+    // and authenticated — cross-service firestore.get() membership checks
+    // proved unreliable here (see band_avatars note above).
+    // ponytail: app-level gating for band writes; move to a callable if abused.
+    match /lab_audio/user/{uid}/{songId}/{fileName} {
+      allow read: if request.auth != null && request.auth.uid == uid;
+      allow write: if request.auth != null && request.auth.uid == uid &&
+        request.resource.size < 25 * 1024 * 1024;
+      allow delete: if request.auth != null && request.auth.uid == uid;
+    }
+    match /lab_audio/band/{bandId}/{songId}/{fileName} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null &&
+        request.resource.size < 25 * 1024 * 1024;
+      allow delete: if request.auth != null;
+    }
+
     match /{allPaths=**} {
       allow read, write: if false;
     }

--- a/web/version.json
+++ b/web/version.json
@@ -1,5 +1,5 @@
 {
   "version": "0.16.0",
   "buildNumber": "336",
-  "buildDate": "2026-07-16T14:27:43Z"
+  "buildDate": "2026-07-16T15:32:10Z"
 }


### PR DESCRIPTION
Closes #69 (manual close after merge). Stacked on #136 → #135. Last piece of the Song Lab epic #65.

- **+ Recording** in the Lab quick-adds: record in-app (mic permission already present for the tuner; `record` file API — first file-based use) **or attach an audio file**; title + manual timestamp notes per the spec ("00:42 good chorus entry"). Web builds are attach-only (recording needs the mobile app — stated in the sheet).
- **Storage**: `lab_audio/{user|band}/{ownerId}/{songId}/{entryId}.{ext}` via the web-safe `putData` path; 25MB enforced client-side and in **storage.rules (deployed)**. Personal path owner-locked; band path mirrors the `band_avatars` trust model (unguessable-URL reads for signed-in users; cross-service `firestore.get()` membership checks are unreliable in Storage rules — ponytail note in the rules, callable upgrade path named).
- **Playback**: inline play/pause + position on recording entries via `just_audio` 0.10.6 — the one new dependency (record captures but can't play). No waveform, no editing — the epic's "capture, don't edit" guardrail.

Suite green (1994), analyze 0 errors. Device verification pending (mic capture + upload + playback needs real hardware — will verify on the Android device after the stack merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)