### PR TITLE
feat(eventkit): data model (#52)

### DIFF
--- a/lib/models/event_kit.dart
+++ b/lib/models/event_kit.dart
@@ -1,0 +1,155 @@
+/// Event Kit (#52): stage plot, crew/guests and rider attached to a setlist —
+/// stored as one inline map on the Setlist doc (no rules changes needed).
+/// Stage is a fixed 3×3 zone grid (v1 — free-drag if beta asks).
+library;
+
+/// Fixed zone ids, back row (upstage) → front row (audience).
+const stageZoneIds = [
+  'back-left', 'back-center', 'back-right',
+  'mid-left', 'mid-center', 'mid-right',
+  'front-left', 'front-center', 'front-right',
+];
+
+class StagePlacement {
+  const StagePlacement({required this.kind, required this.label, this.uid});
+
+  factory StagePlacement.fromJson(Map<String, dynamic> json) =>
+      StagePlacement(
+        kind: json['kind'] as String? ?? 'equipment',
+        label: json['label'] as String? ?? '',
+        uid: json['uid'] as String?,
+      );
+
+  /// 'member' | 'equipment'.
+  final String kind;
+  final String label;
+
+  /// Band member uid when [kind] == 'member'.
+  final String? uid;
+
+  Map<String, dynamic> toJson() => {
+    'kind': kind,
+    'label': label,
+    if (uid != null) 'uid': uid,
+  };
+}
+
+/// Non-band people: photographer, videographer, manager, +1 guests.
+class EventPerson {
+  const EventPerson({
+    required this.name,
+    required this.role,
+    this.notes,
+    this.uid,
+  });
+
+  factory EventPerson.fromJson(Map<String, dynamic> json) => EventPerson(
+    name: json['name'] as String? ?? '',
+    role: json['role'] as String? ?? '',
+    notes: json['notes'] as String?,
+    uid: json['uid'] as String?,
+  );
+
+  final String name;
+  final String role;
+  final String? notes;
+  final String? uid;
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'role': role,
+    if (notes != null) 'notes': notes,
+    if (uid != null) 'uid': uid,
+  };
+}
+
+class RiderItem {
+  const RiderItem({
+    required this.label,
+    this.qty,
+    this.notes,
+    this.done = false,
+  });
+
+  factory RiderItem.fromJson(Map<String, dynamic> json) => RiderItem(
+    label: json['label'] as String? ?? '',
+    qty: (json['qty'] as num?)?.toInt(),
+    notes: json['notes'] as String?,
+    done: json['done'] as bool? ?? false,
+  );
+
+  final String label;
+  final int? qty;
+  final String? notes;
+  final bool done;
+
+  RiderItem copyWith({String? label, int? qty, String? notes, bool? done}) =>
+      RiderItem(
+        label: label ?? this.label,
+        qty: qty ?? this.qty,
+        notes: notes ?? this.notes,
+        done: done ?? this.done,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'label': label,
+    if (qty != null) 'qty': qty,
+    if (notes != null) 'notes': notes,
+    'done': done,
+  };
+}
+
+class EventKit {
+  const EventKit({
+    this.stage = const {},
+    this.people = const [],
+    this.rider = const [],
+  });
+
+  factory EventKit.fromJson(Map<String, dynamic> json) => EventKit(
+    stage: {
+      for (final e in (json['stage'] as Map<String, dynamic>? ?? {}).entries)
+        if (stageZoneIds.contains(e.key))
+          e.key: [
+            for (final p in (e.value as List? ?? []))
+              if (p is Map)
+                StagePlacement.fromJson(Map<String, dynamic>.from(p)),
+          ],
+    },
+    people: [
+      for (final p in (json['people'] as List? ?? []))
+        if (p is Map) EventPerson.fromJson(Map<String, dynamic>.from(p)),
+    ],
+    rider: [
+      for (final r in (json['rider'] as List? ?? []))
+        if (r is Map) RiderItem.fromJson(Map<String, dynamic>.from(r)),
+    ],
+  );
+
+  /// zoneId → placements. Only [stageZoneIds] keys are valid.
+  final Map<String, List<StagePlacement>> stage;
+  final List<EventPerson> people;
+  final List<RiderItem> rider;
+
+  bool get isEmpty => stage.isEmpty && people.isEmpty && rider.isEmpty;
+
+  EventKit copyWith({
+    Map<String, List<StagePlacement>>? stage,
+    List<EventPerson>? people,
+    List<RiderItem>? rider,
+  }) => EventKit(
+    stage: stage ?? this.stage,
+    people: people ?? this.people,
+    rider: rider ?? this.rider,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'stage': {
+      for (final e in stage.entries)
+        if (e.value.isNotEmpty)
+          e.key: e.value.map((p) => p.toJson()).toList(),
+    },
+    'people': people.map((p) => p.toJson()).toList(),
+    'rider': rider.map((r) => r.toJson()).toList(),
+  };
+}

--- a/lib/models/setlist.dart
+++ b/lib/models/setlist.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 import 'band.dart';
+import 'event_kit.dart';
 import 'setlist_assignment.dart';
 
 part 'setlist.g.dart';
@@ -61,6 +62,7 @@ class Setlist {
     this.items = const [],
     this.totalDuration,
     this.assignments = const {},
+    this.eventKit,
   });
 
   factory Setlist.fromJson(Map<String, dynamic> json) =>
@@ -87,6 +89,11 @@ class Setlist {
     toJson: _assignmentsToJson,
   )
   final Map<String, SetlistAssignment> assignments;
+
+  /// Event Kit (#52): stage plot, crew/guests, rider — inline map, nullable
+  /// for every pre-existing doc.
+  @JsonKey(fromJson: _eventKitFromJson, toJson: _eventKitToJson)
+  final EventKit? eventKit;
   @JsonKey(fromJson: _parseDateTime, toJson: _dateTimeToJson)
   final DateTime createdAt;
   @JsonKey(fromJson: _parseDateTime, toJson: _dateTimeToJson)
@@ -103,6 +110,7 @@ class Setlist {
     List<SetlistItem>? items,
     Object? totalDuration = _sentinel,
     Map<String, SetlistAssignment>? assignments,
+    Object? eventKit = _sentinel,
     DateTime? createdAt,
     DateTime? updatedAt,
   }) {
@@ -125,6 +133,7 @@ class Setlist {
           ? this.totalDuration
           : totalDuration as int?,
       assignments: assignments ?? this.assignments,
+      eventKit: eventKit == _sentinel ? this.eventKit : eventKit as EventKit?,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );
@@ -282,3 +291,9 @@ List<SetlistItem> _itemsFromJson(dynamic value) {
 List<Map<String, dynamic>> _itemsToJson(List<SetlistItem> value) {
   return value.map((item) => item.toJson()).toList();
 }
+
+EventKit? _eventKitFromJson(dynamic value) => value is Map
+    ? EventKit.fromJson(Map<String, dynamic>.from(value))
+    : null;
+
+Map<String, dynamic>? _eventKitToJson(EventKit? kit) => kit?.toJson();

--- a/lib/models/setlist.g.dart
+++ b/lib/models/setlist.g.dart
@@ -23,6 +23,7 @@ Setlist _$SetlistFromJson(Map<String, dynamic> json) => Setlist(
   assignments: json['assignments'] == null
       ? {}
       : _assignmentsFromJson(json['assignments']),
+  eventKit: _eventKitFromJson(json['eventKit']),
 );
 
 Map<String, dynamic> _$SetlistToJson(Setlist instance) => <String, dynamic>{
@@ -36,6 +37,7 @@ Map<String, dynamic> _$SetlistToJson(Setlist instance) => <String, dynamic>{
   'items': _itemsToJson(instance.items),
   'totalDuration': instance.totalDuration,
   'assignments': _assignmentsToJson(instance.assignments),
+  'eventKit': _eventKitToJson(instance.eventKit),
   'createdAt': _dateTimeToJson(instance.createdAt),
   'updatedAt': _dateTimeToJson(instance.updatedAt),
 };

--- a/test/models/event_kit_test.dart
+++ b/test/models/event_kit_test.dart
@@ -1,0 +1,70 @@
+import 'package:flowgroove/models/event_kit.dart';
+import 'package:flowgroove/models/setlist.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('EventKit (#52)', () {
+    test('round-trips through JSON', () {
+      const kit = EventKit(
+        stage: {
+          'back-left': [
+            StagePlacement(kind: 'member', label: 'Alex (drums)', uid: 'u1'),
+            StagePlacement(kind: 'equipment', label: 'Amp'),
+          ],
+        },
+        people: [
+          EventPerson(name: 'Vera', role: 'Photographer', notes: 'arrives 19h'),
+        ],
+        rider: [
+          RiderItem(label: 'XLR cables', qty: 4),
+          RiderItem(label: 'Monitor wedge', done: true),
+        ],
+      );
+
+      final back = EventKit.fromJson(kit.toJson());
+      expect(back.stage['back-left'], hasLength(2));
+      expect(back.stage['back-left']!.first.uid, 'u1');
+      expect(back.people.single.role, 'Photographer');
+      expect(back.rider.first.qty, 4);
+      expect(back.rider.last.done, isTrue);
+      expect(back.isEmpty, isFalse);
+    });
+
+    test('unknown zone ids are dropped on parse', () {
+      final back = EventKit.fromJson({
+        'stage': {
+          'balcony': [
+            {'kind': 'equipment', 'label': 'Disco ball'},
+          ],
+          'front-center': [
+            {'kind': 'member', 'label': 'Vera (vocals)'},
+          ],
+        },
+      });
+      expect(back.stage.containsKey('balcony'), isFalse);
+      expect(back.stage['front-center'], hasLength(1));
+    });
+
+    test('Setlist carries eventKit and legacy docs stay null', () {
+      final legacy = Setlist.fromJson({
+        'id': 's1',
+        'bandId': 'b1',
+        'name': 'Gig',
+        'createdAt': '2026-07-16T12:00:00.000',
+        'updatedAt': '2026-07-16T12:00:00.000',
+      });
+      expect(legacy.eventKit, isNull);
+
+      final withKit = legacy.copyWith(
+        eventKit: const EventKit(rider: [RiderItem(label: 'Water')]),
+      );
+      final json = withKit.toJson();
+      final back = Setlist.fromJson(json);
+      expect(back.eventKit!.rider.single.label, 'Water');
+
+      // Sentinel copyWith: omitting keeps, explicit null clears.
+      expect(back.copyWith(name: 'X').eventKit, isNotNull);
+      expect(back.copyWith(eventKit: null).eventKit, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #52 (manual close after merge). Foundation PR of the Event Kit epic #51.

- `EventKit` inline on the Setlist doc (`Setlist.eventKit`, nullable — legacy docs unaffected, sentinel copyWith supports clearing). Inline map = **zero Firestore-rules changes** (band setlist writes already validate only id/bandId; personal setlists are owner-only).
- **Stage**: fixed 3×3 zone grid (`stageZoneIds`, back→front); placements are band members (`uid`) or equipment labels. Unknown zone ids are dropped on parse.
- **People**: crew/guests beyond the band (photographer/manager/+1) with role + notes.
- **Rider**: label / qty / notes / done checklist.
- Tests: EventKit round-trip, unknown-zone drop, Setlist legacy-doc null + carry + sentinel-clear. Full suite green (1997), analyze 0 errors. (`setlist.g.dart` regenerated with a full build_runner run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)