### PR TITLE
feat(eventkit): zone-grid stage editor (#53)

### DIFF
--- a/lib/screens/setlists/event_kit_editor_screen.dart
+++ b/lib/screens/setlists/event_kit_editor_screen.dart
@@ -1,0 +1,475 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/band.dart';
+import '../../models/event_kit.dart';
+import '../../models/setlist.dart';
+import '../../providers/auth/auth_provider.dart';
+import '../../providers/data/data_providers.dart';
+import '../../theme/mono_pulse_theme.dart';
+import '../../utils/member_label.dart';
+import '../../utils/snackbar.dart';
+import '../../widgets/bottom_nav_or_action_bar.dart';
+
+/// Event Kit editor (#53): who stands where (3×3 stage zone grid), crew &
+/// guests, and the rider checklist. Every mutation autosaves the setlist.
+// ponytail: zone grid, not a free-drag canvas — upgrade if beta asks.
+class EventKitEditorScreen extends ConsumerStatefulWidget {
+  const EventKitEditorScreen({required this.setlist, this.bandId, super.key});
+
+  final Setlist setlist;
+  final String? bandId;
+
+  @override
+  ConsumerState<EventKitEditorScreen> createState() =>
+      _EventKitEditorScreenState();
+}
+
+class _EventKitEditorScreenState extends ConsumerState<EventKitEditorScreen> {
+  late EventKit _kit = widget.setlist.eventKit ?? const EventKit();
+
+  List<BandMember> get _members {
+    if (widget.bandId == null) return const [];
+    final bands = ref.read(bandsProvider).value ?? [];
+    return bands.where((b) => b.id == widget.bandId).firstOrNull?.members ??
+        const [];
+  }
+
+  Future<void> _save() async {
+    final updated = widget.setlist.copyWith(
+      eventKit: _kit,
+      updatedAt: DateTime.now(),
+    );
+    try {
+      final firestore = ref.read(firestoreProvider);
+      if (widget.bandId != null) {
+        await firestore.saveBandSetlist(updated, widget.bandId!);
+      } else {
+        final uid = ref.read(currentUserProvider).value?.uid;
+        if (uid == null) return;
+        await firestore.saveSetlist(updated, uid: uid);
+      }
+    } catch (e) {
+      if (mounted) showAppSnackBar(context, 'Save failed: $e');
+    }
+  }
+
+  void _mutate(EventKit next) {
+    setState(() => _kit = next);
+    _save();
+  }
+
+  // ---- stage ----
+
+  Future<void> _addToZone(String zoneId) async {
+    final placement = await showModalBottomSheet<StagePlacement>(
+      context: context,
+      builder: (_) => _AddPlacementSheet(members: _members),
+    );
+    if (placement == null) return;
+    final zone = [..._kit.stage[zoneId] ?? const <StagePlacement>[], placement];
+    _mutate(_kit.copyWith(stage: {..._kit.stage, zoneId: zone}));
+  }
+
+  void _removeFromZone(String zoneId, StagePlacement p) {
+    final zone = [..._kit.stage[zoneId] ?? const <StagePlacement>[]]..remove(p);
+    _mutate(_kit.copyWith(stage: {..._kit.stage, zoneId: zone}));
+  }
+
+  // ---- people / rider ----
+
+  Future<void> _addPerson() async {
+    final person = await showModalBottomSheet<EventPerson>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const _AddPersonSheet(),
+    );
+    if (person == null) return;
+    _mutate(_kit.copyWith(people: [..._kit.people, person]));
+  }
+
+  Future<void> _addRiderItem() async {
+    final label = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const _AddRiderSheet(),
+    );
+    if (label == null || label.isEmpty) return;
+    _mutate(
+      _kit.copyWith(
+        rider: [
+          ..._kit.rider,
+          RiderItem(label: label),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: MonoPulseColors.black,
+      bottomNavigationBar: AppBottomBar.actions(
+        onBack: () => Navigator.pop(context, _kit),
+        title: 'Event kit',
+      ),
+      body: SafeArea(
+        bottom: false,
+        child: ListView(
+          padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+          children: [
+            _sectionTitle('Stage plot'),
+            Text(
+              'Tap a zone to place people and gear. Long-press a chip to '
+              'remove it. Top row is the back of the stage.',
+              style: MonoPulseTypography.bodySmall.copyWith(
+                color: MonoPulseColors.textSecondary,
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            _stageGrid(),
+            const SizedBox(height: 4),
+            Center(
+              child: Text(
+                '▼ audience ▼',
+                style: MonoPulseTypography.bodySmall.copyWith(
+                  color: MonoPulseColors.textSecondary,
+                ),
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.lg),
+            _sectionTitle('Crew & guests'),
+            for (final p in _kit.people)
+              ListTile(
+                dense: true,
+                leading: const Icon(Icons.badge_outlined),
+                title: Text(p.name),
+                subtitle: Text(
+                  [p.role, if (p.notes != null) p.notes!].join(' · '),
+                ),
+                trailing: IconButton(
+                  icon: const Icon(Icons.close, size: 18),
+                  onPressed: () => _mutate(
+                    _kit.copyWith(people: [..._kit.people]..remove(p)),
+                  ),
+                ),
+              ),
+            ActionChip(
+              avatar: const Icon(Icons.person_add_alt, size: 18),
+              label: const Text('Add person'),
+              onPressed: _addPerson,
+            ),
+            const SizedBox(height: MonoPulseSpacing.lg),
+            _sectionTitle('Rider / equipment'),
+            for (final r in _kit.rider)
+              CheckboxListTile(
+                dense: true,
+                controlAffinity: ListTileControlAffinity.leading,
+                title: Text(
+                  '${r.label}${r.qty != null ? ' ×${r.qty}' : ''}',
+                  style: r.done
+                      ? const TextStyle(
+                          decoration: TextDecoration.lineThrough,
+                          color: MonoPulseColors.textSecondary,
+                        )
+                      : null,
+                ),
+                value: r.done,
+                onChanged: (v) => _mutate(
+                  _kit.copyWith(
+                    rider: [
+                      for (final item in _kit.rider)
+                        item == r ? item.copyWith(done: v ?? false) : item,
+                    ],
+                  ),
+                ),
+                secondary: IconButton(
+                  icon: const Icon(Icons.close, size: 18),
+                  onPressed: () =>
+                      _mutate(_kit.copyWith(rider: [..._kit.rider]..remove(r))),
+                ),
+              ),
+            ActionChip(
+              avatar: const Icon(Icons.add, size: 18),
+              label: const Text('Add rider item'),
+              onPressed: _addRiderItem,
+            ),
+            const SizedBox(height: 96),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _sectionTitle(String t) => Padding(
+    padding: const EdgeInsets.only(bottom: MonoPulseSpacing.sm),
+    child: Text(t, style: MonoPulseTypography.titleMedium),
+  );
+
+  Widget _stageGrid() {
+    return Column(
+      children: [
+        for (var row = 0; row < 3; row++)
+          // IntrinsicHeight equalizes cell heights per row; a bare `stretch`
+          // would demand infinite height inside the ListView.
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (var col = 0; col < 3; col++)
+                  Expanded(child: _zoneCell(stageZoneIds[row * 3 + col])),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _zoneCell(String zoneId) {
+    final placements = _kit.stage[zoneId] ?? const <StagePlacement>[];
+    return Padding(
+      padding: const EdgeInsets.all(1),
+      child: InkWell(
+        onTap: () => _addToZone(zoneId),
+        child: Container(
+          constraints: const BoxConstraints(minHeight: 84),
+          padding: const EdgeInsets.all(MonoPulseSpacing.xs),
+          decoration: BoxDecoration(
+            color: MonoPulseColors.surface,
+            border: Border.all(color: MonoPulseColors.borderDefault),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Wrap(
+            spacing: 2,
+            runSpacing: 2,
+            children: [
+              if (placements.isEmpty)
+                const Icon(
+                  Icons.add,
+                  size: 14,
+                  color: MonoPulseColors.textTertiary,
+                ),
+              for (final p in placements)
+                GestureDetector(
+                  onLongPress: () => _removeFromZone(zoneId, p),
+                  child: Chip(
+                    visualDensity: VisualDensity.compact,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    avatar: Icon(
+                      p.kind == 'member' ? Icons.person : Icons.speaker,
+                      size: 12,
+                    ),
+                    label: Text(
+                      p.label,
+                      style: const TextStyle(fontSize: 10),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AddPlacementSheet extends StatelessWidget {
+  const _AddPlacementSheet({required this.members});
+
+  final List<BandMember> members;
+
+  @override
+  Widget build(BuildContext context) {
+    final equipment = TextEditingController();
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: ListView(
+          shrinkWrap: true,
+          padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+          children: [
+            Text(
+              'Place in zone',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: MonoPulseSpacing.sm),
+            for (final m in members)
+              ListTile(
+                dense: true,
+                leading: const Icon(Icons.person),
+                title: Text(
+                  memberLabel(displayName: m.displayName, email: m.email),
+                ),
+                subtitle: m.musicRoles.isEmpty
+                    ? null
+                    : Text(m.musicRoles.join(', ')),
+                onTap: () => Navigator.pop(
+                  context,
+                  StagePlacement(
+                    kind: 'member',
+                    uid: m.uid,
+                    label: memberLabel(
+                      displayName: m.displayName,
+                      email: m.email,
+                    ),
+                  ),
+                ),
+              ),
+            TextField(
+              controller: equipment,
+              decoration: InputDecoration(
+                labelText: 'Equipment (e.g. Amp, Drum kit, Monitor)',
+                border: const OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.add),
+                  onPressed: () {
+                    final label = equipment.text.trim();
+                    if (label.isEmpty) return;
+                    Navigator.pop(
+                      context,
+                      StagePlacement(kind: 'equipment', label: label),
+                    );
+                  },
+                ),
+              ),
+              onSubmitted: (v) {
+                final label = v.trim();
+                if (label.isEmpty) return;
+                Navigator.pop(
+                  context,
+                  StagePlacement(kind: 'equipment', label: label),
+                );
+              },
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AddPersonSheet extends StatefulWidget {
+  const _AddPersonSheet();
+
+  @override
+  State<_AddPersonSheet> createState() => _AddPersonSheetState();
+}
+
+class _AddPersonSheetState extends State<_AddPersonSheet> {
+  final _name = TextEditingController();
+  final _role = TextEditingController();
+  final _notes = TextEditingController();
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _role.dispose();
+    _notes.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Add crew / guest',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            TextField(
+              controller: _name,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'Name',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            TextField(
+              controller: _role,
+              decoration: const InputDecoration(
+                labelText: 'Role (Photographer, Manager, +1…)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            TextField(
+              controller: _notes,
+              decoration: const InputDecoration(
+                labelText: 'Notes (optional)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.lg),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Cancel'),
+                ),
+                const SizedBox(width: MonoPulseSpacing.sm),
+                ElevatedButton(
+                  onPressed: () {
+                    final name = _name.text.trim();
+                    if (name.isEmpty) return;
+                    Navigator.pop(
+                      context,
+                      EventPerson(
+                        name: name,
+                        role: _role.text.trim(),
+                        notes: _notes.text.trim().isEmpty
+                            ? null
+                            : _notes.text.trim(),
+                      ),
+                    );
+                  },
+                  child: const Text('Add'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AddRiderSheet extends StatelessWidget {
+  const _AddRiderSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = TextEditingController();
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+        child: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(
+            labelText: 'Rider item (e.g. XLR cables ×4)',
+            border: OutlineInputBorder(),
+          ),
+          onSubmitted: (v) => Navigator.pop(context, v.trim()),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/setlists/setlist_view_screen.dart
+++ b/lib/screens/setlists/setlist_view_screen.dart
@@ -16,6 +16,7 @@ import '../../widgets/loading_indicator.dart';
 import '../../widgets/menu_items_scope.dart';
 import '../../widgets/setlist_song_row.dart';
 import 'create_setlist_screen.dart' show SetlistStorageScope;
+import 'event_kit_editor_screen.dart';
 
 /// Read-only detail view for a setlist (P1-7 fix).
 ///
@@ -52,6 +53,17 @@ class SetlistViewScreen extends ConsumerWidget {
         ? ref.watch(songsProvider)
         : ref.watch(bandSongsProvider(bandId!));
 
+    // Event Kit reads the LIVE setlist (the constructor arg is a
+    // navigation-time snapshot; the editor autosaves, and this keeps the
+    // summary current after popping back).
+    final liveSetlist =
+        (bandId == null
+                ? ref.watch(setlistsProvider).value
+                : ref.watch(bandSetlistsProvider(bandId!)).value)
+            ?.where((s) => s.id == setlist.id)
+            .firstOrNull ??
+        setlist;
+
     // Publishes into the shell's bottom bar (this is a pushed branch child):
     // the title slot is replaced by the "Open in Metronome" primary action
     // (bar becomes [← Back] [Open in Metronome] [⋮]); Edit — previously an
@@ -70,6 +82,12 @@ class SetlistViewScreen extends ConsumerWidget {
                 extra: setlist,
               ),
             ),
+          if (canEdit)
+            AppMenuItem(
+              icon: Icons.theater_comedy_outlined,
+              label: 'Event kit',
+              onTap: () => _openEventKit(context, liveSetlist),
+            ),
         ],
         primaryAction: CustomButton(
           label: 'Open in Metronome',
@@ -82,22 +100,37 @@ class SetlistViewScreen extends ConsumerWidget {
         body: SafeArea(
           bottom: false,
           child: songsAsync.when(
-            data: (songs) => _buildBody(setlist, songs),
+            data: (songs) =>
+                _buildBody(context, liveSetlist, songs, canEdit: canEdit),
             loading: () => const LoadingIndicator(),
             // A failed songs load shouldn't block the setlist details from
             // showing; song rows just fall back to "unavailable".
-            error: (_, _) => _buildBody(setlist, const []),
+            error: (_, _) =>
+                _buildBody(context, liveSetlist, const [], canEdit: canEdit),
           ),
         ),
       ),
     );
   }
 
-  Widget _buildBody(Setlist setlist, List<Song> allSongs) {
+  void _openEventKit(BuildContext context, Setlist live) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => EventKitEditorScreen(setlist: live, bandId: bandId),
+      ),
+    );
+  }
+
+  Widget _buildBody(
+    BuildContext context,
+    Setlist setlist,
+    List<Song> allSongs, {
+    required bool canEdit,
+  }) {
     final songsById = {for (final song in allSongs) song.id: song};
     final items = setlist.effectiveItems;
 
-    if (items.isEmpty) {
+    if (items.isEmpty && (setlist.eventKit?.isEmpty ?? true)) {
       return const EmptyState(
         icon: Icons.music_note,
         message: 'No songs in this setlist',
@@ -106,8 +139,11 @@ class SetlistViewScreen extends ConsumerWidget {
 
     return ListView.builder(
       padding: const EdgeInsets.all(MonoPulseSpacing.lg),
-      itemCount: items.length,
+      itemCount: items.length + 1,
       itemBuilder: (context, index) {
+        if (index == items.length) {
+          return _eventKitSummary(context, setlist, canEdit: canEdit);
+        }
         final song = songsById[items[index].songId];
         return SetlistSongRow(
           index: index,
@@ -115,6 +151,46 @@ class SetlistViewScreen extends ConsumerWidget {
           trailing: song == null ? null : _badgesFor(song),
         );
       },
+    );
+  }
+
+  /// Event Kit summary below the songs (#53): what's placed, who's coming,
+  /// what to bring — tap opens the editor (edit-gated).
+  Widget _eventKitSummary(
+    BuildContext context,
+    Setlist setlist, {
+    required bool canEdit,
+  }) {
+    final kit = setlist.eventKit;
+    final empty = kit == null || kit.isEmpty;
+    if (empty && !canEdit) return const SizedBox.shrink();
+
+    final placements = kit == null
+        ? 0
+        : kit.stage.values.fold<int>(0, (sum, zone) => sum + zone.length);
+    final openRider = kit?.rider.where((r) => !r.done).length ?? 0;
+
+    return Card(
+      margin: const EdgeInsets.only(top: MonoPulseSpacing.lg),
+      child: ListTile(
+        leading: const Icon(
+          Icons.theater_comedy_outlined,
+          color: MonoPulseColors.accentOrange,
+        ),
+        title: const Text('Event kit'),
+        subtitle: Text(
+          empty
+              ? 'Stage plot, crew & rider for this gig'
+              : [
+                  if (placements > 0) '$placements on stage',
+                  if (kit.people.isNotEmpty) '${kit.people.length} crew/guests',
+                  if (kit.rider.isNotEmpty)
+                    '$openRider of ${kit.rider.length} rider items open',
+                ].join(' · '),
+        ),
+        trailing: canEdit ? const Icon(Icons.chevron_right) : null,
+        onTap: canEdit ? () => _openEventKit(context, setlist) : null,
+      ),
     );
   }
 

--- a/test/screens/setlists/event_kit_editor_test.dart
+++ b/test/screens/setlists/event_kit_editor_test.dart
@@ -1,0 +1,101 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flowgroove/models/event_kit.dart';
+import 'package:flowgroove/models/setlist.dart';
+import 'package:flowgroove/providers/auth/auth_provider.dart';
+import 'package:flowgroove/providers/data/data_providers.dart';
+import 'package:flowgroove/screens/setlists/event_kit_editor_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../helpers/mocks.mocks.dart';
+
+void main() {
+  final setlist = Setlist(
+    id: 'sl1',
+    bandId: '',
+    name: 'Club gig',
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
+
+  Future<MockFirestoreService> pump(WidgetTester tester) async {
+    final firestore = MockFirestoreService();
+    when(firestore.saveSetlist(any, uid: anyNamed('uid')))
+        .thenAnswer((_) async {});
+    final user = MockUser();
+    when(user.uid).thenReturn('u1');
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          firestoreProvider.overrideWithValue(firestore),
+          currentUserProvider.overrideWithValue(AsyncValue<User?>.data(user)),
+        ],
+        child: MaterialApp(home: EventKitEditorScreen(setlist: setlist)),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return firestore;
+  }
+
+  group('EventKitEditorScreen (#53)', () {
+    testWidgets('renders the 9-zone grid and sections', (tester) async {
+      await pump(tester);
+      expect(find.text('Stage plot'), findsOneWidget);
+      expect(find.text('Crew & guests'), findsOneWidget);
+      expect(find.text('Rider / equipment'), findsOneWidget);
+      // 9 empty zones each show a + affordance.
+      expect(find.byIcon(Icons.add), findsWidgets);
+    });
+
+    testWidgets('placing equipment in a zone saves the setlist', (
+      tester,
+    ) async {
+      final firestore = await pump(tester);
+
+      // Tap the first zone cell (top-left = back-left).
+      await tester.tap(find.byIcon(Icons.add).first);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Equipment (e.g. Amp, Drum kit, Monitor)'),
+        'Drum kit',
+      );
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(Chip, 'Drum kit'), findsOneWidget);
+      final saved = verify(
+        firestore.saveSetlist(captureAny, uid: anyNamed('uid')),
+      ).captured.single as Setlist;
+      expect(saved.eventKit!.stage['back-left']!.single.label, 'Drum kit');
+      expect(saved.eventKit!.stage['back-left']!.single.kind, 'equipment');
+    });
+
+    testWidgets('rider item toggles done and persists', (tester) async {
+      final firestore = await pump(tester);
+
+      await tester.scrollUntilVisible(
+        find.text('Add rider item'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.tap(find.text('Add rider item'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, 'XLR cables');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(find.text('XLR cables'), findsOneWidget);
+      await tester.tap(find.byType(Checkbox).first);
+      await tester.pumpAndSettle();
+
+      final saved = verify(
+        firestore.saveSetlist(captureAny, uid: anyNamed('uid')),
+      ).captured.last as Setlist;
+      expect(saved.eventKit!.rider.single.done, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #53 (manual close after merge). Stacked on #138.

- **Editor** (setlist view → Event kit): 3×3 stage grid, back row = upstage, "▼ audience ▼" marker. Tap a zone → sheet listing band members (with music roles) or an equipment field; chips render in-zone (person/speaker icons); long-press removes. Crew & guests (name/role/notes sheet) and rider checklist (add, check off, remove) below. **Autosaves on every mutation** through the existing setlist save paths (band + personal).
- **Setlist view**: summary card under the songs — "4 on stage · 2 crew/guests · 3 of 5 rider items open" — tap-through to the editor (edit-gated, hidden for viewers when empty). Reads the live setlist so it refreshes after editing.
- `// ponytail: zone grid, not a free-drag canvas — upgrade if beta asks.`

Tests: grid renders, equipment placement persists to the right zone, rider done-toggle persists (captured saves on a mocked service). Suite green (2000 🎉), analyze 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)