### PR TITLE
fix(lab): Song Lab entry in edit-song menu

### DIFF
--- a/lib/screens/songs/add_song_screen.dart
+++ b/lib/screens/songs/add_song_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../models/api_error.dart';
@@ -533,6 +534,18 @@ class _AddSongScreenState extends ConsumerState<AddSongScreen>
               label: 'Import lyrics & chords',
               onTap: _importLyrics,
             ),
+            // Lab needs a persisted song (edit mode) — discoverability fix:
+            // the card-overflow entry alone was too hidden (beta feedback).
+            if (widget.song != null)
+              AppMenuItem(
+                icon: Icons.science_outlined,
+                label: 'Song Lab',
+                onTap: () => context.pushNamed(
+                  'song-lab',
+                  pathParameters: {'id': widget.song!.id},
+                  extra: {'song': widget.song, 'bandId': widget.bandId},
+                ),
+              ),
           ],
         ),
         child: Scaffold(

--- a/test/screens/songs/add_song_screen_test.dart
+++ b/test/screens/songs/add_song_screen_test.dart
@@ -72,6 +72,26 @@ void main() {
       // MenuItemsScope for the shell's bottom bar to render.
       final scope = tester.widget<MenuItemsScope>(find.byType(MenuItemsScope));
       expect(scope.title, 'Edit Song');
+      // Song Lab is reachable from the edit menu (discoverability fix) —
+      // only in edit mode, where a persisted song exists.
+      expect(scope.items.map((i) => i.label), contains('Song Lab'));
+    });
+
+    testWidgets('add mode publishes no Song Lab entry', (tester) async {
+      final mockUser = MockDataHelper.createMockAppUser();
+
+      await pumpAppWidget(
+        tester,
+        const AddSongScreen(),
+        overrides: [
+          firebaseAuthProvider.overrideWith((ref) => mockAuth),
+          appUserProvider.overrideWith(() => TestAppUserNotifier(mockUser)),
+          autocompleteSearchProvider.overrideWith(TestAutocompleteNotifier.new),
+        ],
+      );
+
+      final scope = tester.widget<MenuItemsScope>(find.byType(MenuItemsScope));
+      expect(scope.items.map((i) => i.label), isNot(contains('Song Lab')));
     });
 
     testWidgets('displays all form fields with an unset key preview', (


### PR DESCRIPTION
Beta feedback: Song Lab was reachable only from the song card's ⋮ overflow — too hidden for a headline feature (verified the build contained it; pure discoverability). The edit-song screen's menu now lists **Song Lab** (edit mode only — the Lab needs a persisted song). Tests: menu contains it in edit mode, not in add mode. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)