### PR TITLE
feat(eventkit): role cards (#54)

### DIFF
--- a/lib/screens/setlists/event_kit_editor_screen.dart
+++ b/lib/screens/setlists/event_kit_editor_screen.dart
@@ -10,6 +10,7 @@ import '../../theme/mono_pulse_theme.dart';
 import '../../utils/member_label.dart';
 import '../../utils/snackbar.dart';
 import '../../widgets/bottom_nav_or_action_bar.dart';
+import '../../widgets/user_avatar.dart';
 
 /// Event Kit editor (#53): who stands where (3×3 stage zone grid), crew &
 /// guests, and the rider checklist. Every mutation autosaves the setlist.
@@ -194,6 +195,17 @@ class _EventKitEditorScreenState extends ConsumerState<EventKitEditorScreen> {
               label: const Text('Add rider item'),
               onPressed: _addRiderItem,
             ),
+            const SizedBox(height: MonoPulseSpacing.lg),
+            _sectionTitle('Role cards'),
+            Text(
+              'Everyone involved in this event — band, crew and guests. '
+              'These print in the event-guide PDF.',
+              style: MonoPulseTypography.bodySmall.copyWith(
+                color: MonoPulseColors.textSecondary,
+              ),
+            ),
+            const SizedBox(height: MonoPulseSpacing.md),
+            _roleCards(),
             const SizedBox(height: 96),
           ],
         ),
@@ -205,6 +217,78 @@ class _EventKitEditorScreenState extends ConsumerState<EventKitEditorScreen> {
     padding: const EdgeInsets.only(bottom: MonoPulseSpacing.sm),
     child: Text(t, style: MonoPulseTypography.titleMedium),
   );
+
+  /// Role cards (#54): band members + crew/guests, initials-avatar cards.
+  Widget _roleCards() {
+    final cards = <({String name, String role, String? notes})>[
+      for (final m in _members)
+        (
+          name: memberLabel(displayName: m.displayName, email: m.email),
+          role: m.musicRoles.isEmpty ? 'Band' : m.musicRoles.join(', '),
+          notes: null,
+        ),
+      for (final p in _kit.people) (name: p.name, role: p.role, notes: p.notes),
+    ];
+    if (cards.isEmpty) {
+      return Text(
+        'No people yet — band members appear here automatically for band '
+        'setlists; add crew above.',
+        style: MonoPulseTypography.bodySmall.copyWith(
+          color: MonoPulseColors.textTertiary,
+        ),
+      );
+    }
+    return Wrap(
+      spacing: MonoPulseSpacing.md,
+      runSpacing: MonoPulseSpacing.md,
+      children: [for (final c in cards) _roleCard(c)],
+    );
+  }
+
+  Widget _roleCard(({String name, String role, String? notes}) c) {
+    return SizedBox(
+      width: 150,
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(MonoPulseSpacing.md),
+          child: Column(
+            children: [
+              UserAvatar(photoURL: null, displayName: c.name, radius: 22),
+              const SizedBox(height: MonoPulseSpacing.sm),
+              Text(
+                c.name,
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: MonoPulseTypography.bodyMedium.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              Text(
+                c.role,
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: MonoPulseTypography.bodySmall.copyWith(
+                  color: MonoPulseColors.accentOrange,
+                ),
+              ),
+              if (c.notes != null)
+                Text(
+                  c.notes!,
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: MonoPulseTypography.bodySmall.copyWith(
+                    color: MonoPulseColors.textSecondary,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 
   Widget _stageGrid() {
     return Column(

--- a/test/screens/setlists/event_kit_editor_test.dart
+++ b/test/screens/setlists/event_kit_editor_test.dart
@@ -74,6 +74,34 @@ void main() {
       expect(saved.eventKit!.stage['back-left']!.single.kind, 'equipment');
     });
 
+    testWidgets('added crew person appears as a role card (#54)', (
+      tester,
+    ) async {
+      await pump(tester);
+
+      await tester.tap(find.text('Add person'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Name'),
+        'Vera',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Role (Photographer, Manager, +1…)'),
+        'Photographer',
+      );
+      await tester.tap(find.text('Add'));
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.text('Role cards'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      // Vera renders in the crew list AND as a role card.
+      expect(find.text('Vera'), findsNWidgets(2));
+      expect(find.text('Photographer'), findsWidgets);
+    });
+
     testWidgets('rider item toggles done and persists', (tester) async {
       final firestore = await pump(tester);
 


### PR DESCRIPTION
Closes #54 (manual close after merge). Stacked on #139 → #138.

Role cards section in the Event Kit editor: per-person cards (initials avatar via UserAvatar, name, role, notes) for **band members** (auto-included on band setlists, showing their music roles) plus **crew & guests** from the kit. Initials-v1 per the earlier design decision — photos are a follow-up once member-photo lookup exists. These cards print in the event-guide PDF (#55, next).

Test: added crew person renders both in the list and as a card. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)