### PR TITLE
feat(eventkit): event-guide PDF (#55)

### DIFF
--- a/lib/screens/bands/band_setlists_screen.dart
+++ b/lib/screens/bands/band_setlists_screen.dart
@@ -346,7 +346,10 @@ class _BandSetlistsScreenState extends ConsumerState<BandSetlistsScreen> {
   }
 
   Future<void> _exportPdf(Setlist setlist) async {
-    final layout = await pickSetlistPdfLayout(context);
+    final layout = await pickSetlistPdfLayout(
+      context,
+      withEventGuide: setlist.eventKit?.isEmpty == false,
+    );
     if (layout == null) return;
     try {
       await PdfService.exportSetlist(

--- a/lib/screens/setlists/setlists_list_screen.dart
+++ b/lib/screens/setlists/setlists_list_screen.dart
@@ -180,7 +180,9 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
     // (metronome/share/PDF export via _songsForSetlist) read from a warm
     // provider instead of a cold autoDispose read (#80).
     ref.watch(songsProvider);
-    final canEdit = ref.watch(canEditProvider); // false for the shared demo account
+    final canEdit = ref.watch(
+      canEditProvider,
+    ); // false for the shared demo account
 
     return StandardScreenScaffold(
       title: 'Setlists',
@@ -330,7 +332,10 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
   }
 
   Future<void> _exportPdf(Setlist setlist) async {
-    final layout = await pickSetlistPdfLayout(context);
+    final layout = await pickSetlistPdfLayout(
+      context,
+      withEventGuide: setlist.eventKit?.isEmpty == false,
+    );
     if (layout == null) return;
     final setlistSongs = await _songsForSetlist(setlist);
     try {
@@ -340,5 +345,4 @@ class _SetlistsListScreenState extends ConsumerState<SetlistsListScreen> {
       showAppSnackBar(context, 'Error: $e');
     }
   }
-
 }

--- a/lib/services/export/pdf_service.dart
+++ b/lib/services/export/pdf_service.dart
@@ -2,6 +2,7 @@ import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:printing/printing.dart';
 
+import '../../models/event_kit.dart';
 import '../../models/section.dart';
 import '../../models/setlist.dart';
 import '../../models/song.dart';
@@ -10,7 +11,7 @@ import '../../utils/chordpro.dart';
 /// PDF layout for a setlist export.
 /// [pack] = compact setlist page + every song as a one-page compact sheet
 /// (#84; roster/stage map/schedule pages come later).
-enum SetlistPdfLayout { detailed, compact, pack }
+enum SetlistPdfLayout { detailed, compact, pack, eventGuide }
 
 class PdfService {
   /// Exports a single song's performance sheet (chords over lyrics per section)
@@ -94,7 +95,9 @@ class PdfService {
     final font = await PdfGoogleFonts.robotoRegular();
     final fontBold = await PdfGoogleFonts.robotoBold();
 
-    final songWidgets = layout == SetlistPdfLayout.detailed
+    final songWidgets =
+        layout == SetlistPdfLayout.detailed ||
+            layout == SetlistPdfLayout.eventGuide
         ? _detailedRows(songs, font, fontBold)
         : _compactRows(songs, font, fontBold);
 
@@ -203,10 +206,17 @@ class PdfService {
       }
     }
 
+    // Event guide (#55): stage plot + role cards + rider after the setlist.
+    if (layout == SetlistPdfLayout.eventGuide) {
+      final kit = setlist.eventKit ?? const EventKit();
+      pdf.addPage(_eventGuidePage(setlist, kit, font, fontBold));
+    }
+
     final suffix = switch (layout) {
       SetlistPdfLayout.detailed => '',
       SetlistPdfLayout.compact => '_compact',
       SetlistPdfLayout.pack => '_pack',
+      SetlistPdfLayout.eventGuide => '_event_guide',
     };
     await Printing.layoutPdf(
       onLayout: (format) async => pdf.save(),
@@ -506,5 +516,151 @@ class PdfService {
       );
     }
     return widgets;
+  }
+
+  /// Event-guide page (#55): stage plot (3×3 zone table), role cards and the
+  /// rider checklist — the venue/crew handout after the setlist pages.
+  static pw.Page _eventGuidePage(
+    Setlist setlist,
+    EventKit kit,
+    pw.Font font,
+    pw.Font fontBold,
+  ) {
+    pw.Widget zoneCell(String zoneId) {
+      final placements = kit.stage[zoneId] ?? const <StagePlacement>[];
+      return pw.Container(
+        padding: const pw.EdgeInsets.all(6),
+        constraints: const pw.BoxConstraints(minHeight: 54),
+        child: pw.Column(
+          crossAxisAlignment: pw.CrossAxisAlignment.start,
+          children: [
+            for (final p in placements)
+              pw.Text(
+                p.kind == 'member' ? '• ${p.label}' : '▪ ${p.label}',
+                style: pw.TextStyle(font: font, fontSize: 9),
+              ),
+          ],
+        ),
+      );
+    }
+
+    final dateLine = [
+      if (setlist.eventDateTime != null) setlist.formattedEventDate,
+      if (setlist.eventLocation != null) setlist.eventLocation!,
+    ].join(' · ');
+
+    return pw.Page(
+      pageFormat: PdfPageFormat.a4,
+      margin: const pw.EdgeInsets.all(40),
+      build: (context) => pw.Column(
+        crossAxisAlignment: pw.CrossAxisAlignment.start,
+        children: [
+          pw.Text(
+            'Event guide — ${setlist.name}',
+            style: pw.TextStyle(font: fontBold, fontSize: 20),
+          ),
+          if (dateLine.isNotEmpty)
+            pw.Text(dateLine, style: pw.TextStyle(font: font, fontSize: 11)),
+          pw.SizedBox(height: 16),
+          pw.Text(
+            'Stage plot (top = back of stage)',
+            style: pw.TextStyle(font: fontBold, fontSize: 13),
+          ),
+          pw.SizedBox(height: 6),
+          pw.Table(
+            border: pw.TableBorder.all(color: PdfColor.fromHex('BDBDBD')),
+            children: [
+              for (var row = 0; row < 3; row++)
+                pw.TableRow(
+                  children: [
+                    for (var col = 0; col < 3; col++)
+                      zoneCell(stageZoneIds[row * 3 + col]),
+                  ],
+                ),
+            ],
+          ),
+          pw.SizedBox(height: 2),
+          pw.Center(
+            child: pw.Text(
+              'AUDIENCE',
+              style: pw.TextStyle(
+                font: font,
+                fontSize: 8,
+                color: PdfColor.fromHex('757575'),
+              ),
+            ),
+          ),
+          if (kit.people.isNotEmpty) ...[
+            pw.SizedBox(height: 16),
+            pw.Text(
+              'Crew & guests',
+              style: pw.TextStyle(font: fontBold, fontSize: 13),
+            ),
+            pw.SizedBox(height: 6),
+            pw.Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final p in kit.people)
+                  pw.Container(
+                    width: 160,
+                    padding: const pw.EdgeInsets.all(8),
+                    decoration: pw.BoxDecoration(
+                      border: pw.Border.all(color: PdfColor.fromHex('BDBDBD')),
+                      borderRadius: pw.BorderRadius.circular(4),
+                    ),
+                    child: pw.Column(
+                      crossAxisAlignment: pw.CrossAxisAlignment.start,
+                      children: [
+                        pw.Text(
+                          p.name,
+                          style: pw.TextStyle(font: fontBold, fontSize: 11),
+                        ),
+                        pw.Text(
+                          p.role,
+                          style: pw.TextStyle(font: font, fontSize: 9),
+                        ),
+                        if (p.notes != null)
+                          pw.Text(
+                            p.notes!,
+                            style: pw.TextStyle(
+                              font: font,
+                              fontSize: 8,
+                              color: PdfColor.fromHex('757575'),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ],
+          if (kit.rider.isNotEmpty) ...[
+            pw.SizedBox(height: 16),
+            pw.Text(
+              'Rider / equipment',
+              style: pw.TextStyle(font: fontBold, fontSize: 13),
+            ),
+            pw.SizedBox(height: 6),
+            for (final r in kit.rider)
+              pw.Text(
+                '${r.done ? '☑' : '☐'}  ${r.label}'
+                '${r.qty != null ? '  ×${r.qty}' : ''}'
+                '${r.notes != null ? '  — ${r.notes}' : ''}',
+                style: pw.TextStyle(font: font, fontSize: 10),
+              ),
+          ],
+          pw.Spacer(),
+          pw.Text(
+            'Generated by FlowGroove',
+            style: pw.TextStyle(
+              font: font,
+              fontSize: 8,
+              color: PdfColor.fromHex('9E9E9E'),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/services/export/setlist_export_sheet.dart
+++ b/lib/services/export/setlist_export_sheet.dart
@@ -4,14 +4,17 @@ import 'pdf_service.dart';
 
 /// Bottom sheet that lets the user pick a setlist PDF layout.
 /// Returns null if dismissed.
-Future<SetlistPdfLayout?> pickSetlistPdfLayout(BuildContext context) =>
-    _pickPdfLayout(
-      context,
-      asIsSubtitle: 'One card per song, full detail',
-      compactIcon: Icons.format_list_bulleted,
-      compactSubtitle: 'One line per song, fits on one list',
-      withPack: true,
-    );
+Future<SetlistPdfLayout?> pickSetlistPdfLayout(
+  BuildContext context, {
+  bool withEventGuide = false,
+}) => _pickPdfLayout(
+  context,
+  asIsSubtitle: 'One card per song, full detail',
+  compactIcon: Icons.format_list_bulleted,
+  compactSubtitle: 'One line per song, fits on one list',
+  withPack: true,
+  withEventGuide: withEventGuide,
+);
 
 /// Same picker for a song performance-sheet PDF (#79): "As is" flows across
 /// pages, "Compact" scales everything onto a single A4 page.
@@ -29,6 +32,7 @@ Future<SetlistPdfLayout?> _pickPdfLayout(
   required IconData compactIcon,
   required String compactSubtitle,
   bool withPack = false,
+  bool withEventGuide = false,
 }) {
   return showModalBottomSheet<SetlistPdfLayout>(
     context: context,
@@ -56,6 +60,16 @@ Future<SetlistPdfLayout?> _pickPdfLayout(
                 'Compact setlist + one-page sheet per song',
               ),
               onTap: () => Navigator.pop(context, SetlistPdfLayout.pack),
+            ),
+          if (withEventGuide)
+            ListTile(
+              leading: const Icon(Icons.theater_comedy),
+              title: const Text('Event guide'),
+              subtitle: const Text(
+                'Cover + setlist + stage plot + role cards + rider',
+              ),
+              onTap: () =>
+                  Navigator.pop(context, SetlistPdfLayout.eventGuide),
             ),
         ],
       ),

--- a/test/services/event_guide_export_test.dart
+++ b/test/services/event_guide_export_test.dart
@@ -1,0 +1,54 @@
+import 'package:flowgroove/services/export/pdf_service.dart';
+import 'package:flowgroove/services/export/setlist_export_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final results = <Future<SetlistPdfLayout?>>[];
+
+  Future<void> pumpAndOpen(
+    WidgetTester tester, {
+    required bool withEventGuide,
+  }) async {
+    results.clear();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () {
+              results.add(
+                pickSetlistPdfLayout(
+                  context,
+                  withEventGuide: withEventGuide,
+                ),
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('Event guide export option (#55)', () {
+    testWidgets('picker offers Event guide when the kit exists', (
+      tester,
+    ) async {
+      await pumpAndOpen(tester, withEventGuide: true);
+
+      expect(find.text('Event guide'), findsOneWidget);
+      await tester.tap(find.text('Event guide'));
+      await tester.pumpAndSettle();
+      expect(await results.single, SetlistPdfLayout.eventGuide);
+    });
+
+    testWidgets('picker hides Event guide without a kit', (tester) async {
+      await pumpAndOpen(tester, withEventGuide: false);
+
+      expect(find.text('Event guide'), findsNothing);
+      expect(find.text('SetlistPack'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #55 (manual close after merge). Top of the Event Kit stack (#138 → #139 → #141 → this). Completes epic #51.

- **Export picker** gains "Event guide — cover + setlist + stage plot + role cards + rider", shown only when the setlist actually has a kit (both personal and band export paths wired).
- **Guide page** after the detailed setlist pages: title + date/location line · **stage plot** as a bordered 3×3 table (• members, ▪ equipment; "top = back of stage" + AUDIENCE marker) · **crew/guest cards** (name/role/notes boxes) · **rider checklist** with ☐/☑ carrying the in-app done state. Drawn natively with `pw` primitives — no widget-to-image plumbing needed thanks to the zone model.
- One shareable document for the venue/security/club, per the epic goal. This also completes the crew/stage extras deferred from #84.

Tests: picker shows/hides the option by kit presence and returns the enum. Suite green (2003), analyze 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)