### PR TITLE
feat(cards): two-deck unified card (#86)

### DIFF
--- a/lib/widgets/unified_item/unified_item_card.dart
+++ b/lib/widgets/unified_item/unified_item_card.dart
@@ -5,13 +5,18 @@ import '../band_avatar.dart';
 import 'adapters/band_item_adapter.dart';
 import 'adapters/setlist_item_adapter.dart';
 import 'adapters/song_item_adapter.dart';
-import 'unified_item_badge.dart';
 import 'unified_item_model.dart';
 import 'unified_item_trailing_actions.dart';
 
-/// Unified card widget for displaying items (Song, Band, Setlist)
+/// Unified card for Songs, Bands and Setlists (#86 redesign).
+///
+/// Two decks instead of a ListTile: the title deck owns the card's full
+/// width (no trailing cluster stealing room — the old layout squashed long
+/// titles on phones), and the meta rail below carries badges on the left and
+/// the actions on the right. Songs always reserve the rail so cards stay the
+/// same height whether or not key/BPM exist (audit P2-14); the key chip uses
+/// the same orange treatment everywhere (audit P2-4).
 class UnifiedItemCard<T extends UnifiedItemModel> extends StatelessWidget {
-
   const UnifiedItemCard({
     required this.item,
     super.key,
@@ -30,246 +35,206 @@ class UnifiedItemCard<T extends UnifiedItemModel> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final actions = UnifiedItemTrailingActions(
+      item: item,
+      onEdit: onEdit,
+      onDelete: onDelete,
+      customActions: customActions,
+      showCompact: showCompact,
+    );
+
     return Card(
-      margin: const EdgeInsets.symmetric(horizontal: MonoPulseSpacing.lg, vertical: MonoPulseSpacing.sm),
+      margin: const EdgeInsets.symmetric(
+        horizontal: MonoPulseSpacing.lg,
+        vertical: MonoPulseSpacing.sm,
+      ),
       elevation: 0,
       color: Theme.of(context).colorScheme.surface,
-      child: ListTile(
-        leading: _buildLeadingIcon(context),
-        title: Text(
-          item.title,
-          style: showCompact
-              ? MonoPulseTypography.bodyMedium.copyWith(
-                  fontWeight: FontWeight.w500,
-                )
-              : MonoPulseTypography.titleLarge.copyWith(
-                  fontSize: 18,
-                  fontWeight: FontWeight.w700,
-                ),
-        ),
-        subtitle: _buildSubtitle(context),
-        trailing: UnifiedItemTrailingActions(
-          item: item,
-          onEdit: onEdit,
-          onDelete: onDelete,
-          customActions: customActions,
-          showCompact: showCompact,
-        ),
+      child: InkWell(
         onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: MonoPulseSpacing.lg,
+            vertical: showCompact ? MonoPulseSpacing.sm : MonoPulseSpacing.md,
+          ),
+          child: Row(
+            children: [
+              ..._leading(context),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Title deck: full card width, nothing competes with it.
+                    Text(
+                      item.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: showCompact
+                          ? MonoPulseTypography.bodyMedium.copyWith(
+                              fontWeight: FontWeight.w500,
+                            )
+                          : MonoPulseTypography.titleLarge.copyWith(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                            ),
+                    ),
+                    if (!showCompact && _subtitleText() != null)
+                      Text(
+                        _subtitleText()!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: MonoPulseTypography.bodySmall.copyWith(
+                          color: MonoPulseColors.textSecondary,
+                        ),
+                      ),
+                    SizedBox(height: showCompact ? 0 : MonoPulseSpacing.xs),
+                    // Meta rail: badges left, actions right — actions live in
+                    // the thumb-friendly lower half, off the title's row.
+                    Row(
+                      children: [
+                        Expanded(child: _metaRail(context)),
+                        actions,
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
 
-  Widget? _buildLeadingIcon(BuildContext context) {
-    IconData icon;
-
-    if (item is SongItemAdapter) {
-      // No leading avatar for songs — the title needs the room on phones,
-      // and copy status is already shown by the attribution line.
-      return null;
-    } else if (item is BandItemAdapter) {
-      // Show the band's avatar when it has one, falling back to initials.
+  List<Widget> _leading(BuildContext context) {
+    // Songs get no avatar — titles need the room on phones.
+    if (item is SongItemAdapter) return const [];
+    Widget avatar;
+    if (item is BandItemAdapter) {
       final band = (item as BandItemAdapter).band;
-      if (band.photoURL != null) {
-        return BandAvatar(
-          photoURL: band.photoURL,
-          bandName: band.name,
-          radius: 20,
-        );
-      }
-      icon = Icons.groups;
-    } else if (item is SetlistItemAdapter) {
-      icon = Icons.playlist_play;
+      avatar = BandAvatar(
+        photoURL: band.photoURL,
+        bandName: band.name,
+        radius: 20,
+      );
     } else {
-      icon = Icons.info;
+      avatar = const CircleAvatar(
+        backgroundColor: MonoPulseColors.surfaceRaised,
+        child: Icon(Icons.playlist_play, color: MonoPulseColors.accentOrange),
+      );
     }
-
-    return CircleAvatar(
-      backgroundColor: MonoPulseColors.surfaceRaised,
-      child: Icon(icon, color: MonoPulseColors.accentOrange),
-    );
+    return [avatar, const SizedBox(width: MonoPulseSpacing.md)];
   }
 
-  Widget _buildSubtitle(BuildContext context) {
-    if (showCompact) {
-      return _buildCompactSubtitle();
-    }
+  /// One-line secondary text under the title (artist / description).
+  String? _subtitleText() {
+    final text = switch (item) {
+      SongItemAdapter(:final subtitle) => subtitle,
+      BandItemAdapter(:final subtitle) => subtitle,
+      _ => null,
+    };
+    return (text?.isNotEmpty ?? false) ? text : null;
+  }
 
-    final List<Widget> subtitleWidgets = [];
-
-    // Song subtitle
+  /// The badge/attribution line. Songs always render the rail (reserved
+  /// height); bands/setlists show their counts here.
+  Widget _metaRail(BuildContext context) {
     if (item is SongItemAdapter) {
       final song = item as SongItemAdapter;
-      if (song.subtitle?.isNotEmpty == true) {
-        subtitleWidgets.add(
-          Text(
-            song.subtitle!,
-            style: MonoPulseTypography.bodySmall,
-          ),
-        );
-      }
-
-      // Add BPM and key badges - enhanced BPM display
-      final List<Widget> badges = [];
+      final displayKey = song.ourKey ?? song.originalKey;
       final displayBPM = song.displayBPM;
-      if (displayBPM != null) {
-        badges.add(
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.speed,
-                size: 14,
-                color: MonoPulseColors.accentOrange,
-              ),
-              const SizedBox(width: 4),
-              Text(
-                '$displayBPM BPM',
-                style: MonoPulseTypography.bodySmall.copyWith(
+      return Wrap(
+        spacing: MonoPulseSpacing.md,
+        runSpacing: 2,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          _keyChip(displayKey),
+          if (displayBPM != null)
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.speed,
+                  size: 14,
                   color: MonoPulseColors.accentOrange,
-                  fontWeight: FontWeight.w700,
                 ),
-              ),
-            ],
-          ),
-        );
-      }
-      final displayKey = song.ourKey ?? song.originalKey;
-      if (displayKey != null) {
-        badges.add(
-          UnifiedItemBadge(
-            text: displayKey,
-            color: MonoPulseColors.textTertiary,
-          ),
-        );
-      }
-
-      if (badges.isNotEmpty) {
-        subtitleWidgets.add(Row(children: badges));
-      }
-
-      // Attribution: band songs name their contributor; personal copies just
-      // note they were shared.
-      if (song.contributedBy != null || song.isCopy) {
-        subtitleWidgets.add(
-          Row(
-            children: [
-              const Icon(
-                Icons.content_copy,
-                size: 12,
-                color: MonoPulseColors.accentOrange,
-              ),
-              const SizedBox(width: 4),
-              Text(
-                song.contributedBy != null
-                    ? 'Added by ${song.contributedBy}'
-                    : 'Shared to band',
-                style: MonoPulseTypography.labelSmall.copyWith(
-                  color: MonoPulseColors.accentOrange,
-                  fontWeight: FontWeight.w500,
+                const SizedBox(width: 4),
+                Text(
+                  '$displayBPM',
+                  style: MonoPulseTypography.bodySmall.copyWith(
+                    color: MonoPulseColors.accentOrange,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-              ),
-            ],
-          ),
-        );
-      }
-    }
-    // Band subtitle
-    // Band subtitle
-    else if (item is BandItemAdapter) {
-      final band = item as BandItemAdapter;
-      if (band.subtitle?.isNotEmpty == true) {
-        subtitleWidgets.add(
-          Text(
-            band.subtitle!,
-            style: MonoPulseTypography.bodySmall,
-          ),
-        );
-      }
-      final membersCount = band.membersCount;
-      subtitleWidgets.add(
-        Text(
-          '$membersCount ${membersCount == 1 ? 'member' : 'members'}',
-          style: MonoPulseTypography.bodySmall,
-        ),
-      );
-    }
-    // Setlist subtitle
-    else if (item is SetlistItemAdapter) {
-      final adapter = item as SetlistItemAdapter;
-      final setlist = adapter.setlist;
-      final songCount = adapter.songIdsLength;
-      subtitleWidgets.add(
-        Text(
-          '$songCount ${songCount == 1 ? 'song' : 'songs'}',
-          style: MonoPulseTypography.bodySmall,
-        ),
-      );
-
-      if (setlist.eventDateTime != null) {
-        subtitleWidgets.add(
-          Text(
-            setlist.formattedEventDate,
-            style: MonoPulseTypography.bodySmall,
-          ),
-        );
-      }
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: subtitleWidgets,
-    );
-  }
-
-  Widget _buildCompactSubtitle() {
-    final List<Widget> compactSubtitles = [];
-
-    if (item is SongItemAdapter) {
-      final song = item as SongItemAdapter;
-      final displayKey = song.ourKey ?? song.originalKey;
-      if (displayKey != null) {
-        compactSubtitles.add(
-          Text(
-            displayKey,
-            style: MonoPulseTypography.bodySmall.copyWith(
-              color: MonoPulseColors.textTertiary,
-              fontWeight: FontWeight.w700,
+              ],
             ),
-          ),
-        );
-      }
-      final displayBPM = song.displayBPM;
-      if (displayBPM != null) {
-        compactSubtitles.add(const SizedBox(width: 8));
-        compactSubtitles.add(
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.speed,
-                size: 14,
-                color: MonoPulseColors.accentOrange,
-              ),
-              const SizedBox(width: 2),
-              Text(
-                '$displayBPM BPM',
-                style: MonoPulseTypography.bodySmall,
-              ),
-            ],
-          ),
-        );
-      }
-    } else if (item is SetlistItemAdapter) {
-      final setlist = item as SetlistItemAdapter;
-      compactSubtitles.add(
-        Text(
-          '${setlist.songIdsLength} songs',
-          style: MonoPulseTypography.bodySmall,
-        ),
+          if (song.contributedBy != null || song.isCopy)
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.content_copy,
+                  size: 12,
+                  color: MonoPulseColors.textTertiary,
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  song.contributedBy != null
+                      ? 'Added by ${song.contributedBy}'
+                      : 'Shared to band',
+                  style: MonoPulseTypography.labelSmall.copyWith(
+                    color: MonoPulseColors.textTertiary,
+                  ),
+                ),
+              ],
+            ),
+        ],
       );
     }
+    if (item is BandItemAdapter) {
+      final membersCount = (item as BandItemAdapter).membersCount;
+      return Text(
+        '$membersCount ${membersCount == 1 ? 'member' : 'members'}',
+        style: MonoPulseTypography.bodySmall,
+      );
+    }
+    if (item is SetlistItemAdapter) {
+      final adapter = item as SetlistItemAdapter;
+      final songCount = adapter.songIdsLength;
+      final setlist = adapter.setlist;
+      return Text(
+        [
+          '$songCount ${songCount == 1 ? 'song' : 'songs'}',
+          if (setlist.eventDateTime != null) setlist.formattedEventDate,
+        ].join(' · '),
+        style: MonoPulseTypography.bodySmall,
+      );
+    }
+    return const SizedBox.shrink();
+  }
 
-    return Row(children: compactSubtitles);
+  /// Key chip — same treatment as the setlist view badges (orange on
+  /// orange10); '—' keeps the slot when the key is unset, so card heights
+  /// never jump between rows.
+  Widget _keyChip(String? key) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: key != null
+            ? MonoPulseColors.accentOrange10
+            : MonoPulseColors.surfaceRaised,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        key ?? '—',
+        style: MonoPulseTypography.bodySmall.copyWith(
+          fontWeight: FontWeight.w700,
+          color: key != null
+              ? MonoPulseColors.accentOrange
+              : MonoPulseColors.textTertiary,
+        ),
+      ),
+    );
   }
 }

--- a/test/screens/setlists/setlists_list_screen_test.dart
+++ b/test/screens/setlists/setlists_list_screen_test.dart
@@ -91,9 +91,10 @@ void main() {
 
       expect(find.text('Gig Setlist'), findsOneWidget);
       expect(find.text('Practice Setlist'), findsOneWidget);
-      expect(find.text('3 songs'), findsOneWidget);
-      expect(find.text('1 song'), findsOneWidget);
-      expect(find.text('10.05.2026'), findsOneWidget);
+      // #86 rail: counts and event date share one line, dot-separated.
+      expect(find.textContaining('3 songs'), findsOneWidget);
+      expect(find.textContaining('1 song'), findsOneWidget);
+      expect(find.textContaining('10.05.2026'), findsOneWidget);
       expect(find.byIcon(Icons.playlist_play), findsWidgets);
     });
 

--- a/test/screens/songs/songs_list_screen_test.dart
+++ b/test/screens/songs/songs_list_screen_test.dart
@@ -128,10 +128,11 @@ void main() {
 
       expect(find.text('Song One'), findsOneWidget);
       expect(find.text('Artist One'), findsOneWidget);
-      expect(find.text('120 BPM'), findsOneWidget);
+      // #86 rail: BPM renders as a bare number beside the speed icon.
+      expect(find.text('120'), findsOneWidget);
       expect(find.text('C'), findsOneWidget);
       expect(find.text('Song Two'), findsOneWidget);
-      expect(find.text('130 BPM'), findsOneWidget);
+      expect(find.text('130'), findsOneWidget);
       expect(find.text('G'), findsOneWidget);
       expect(
         tester


### PR DESCRIPTION
Closes #86 (manual close after merge — **awaiting device sign-off before merging**). Stacked on #143.

Beta report: "song title and band name could be squashed completely on smaller screens." Root cause: `ListTile` renders the trailing action cluster in the title's row, so every icon steals title width.

**Two-deck redesign:**
- **Title deck** — full card width, one ellipsized line, artist in secondary below. Nothing competes with the title anymore.
- **Meta rail** — key chip · BPM · attribution on the left, the quick-action + overflow icons on the right. Actions move out of the title row into the lower half (also resolves the audit's Fitts "three interleaved targets in one corner" finding).
- **Key chip always reserved** ('—' when unset) → constant card heights (audit P2-14); one orange chip treatment everywhere (audit P2-4 inconsistency).
- Bands (avatar + member count) and setlists (counts · date) use the same structure — full parity per the unify rule.

Net −33 lines. Suite green (2009), analyze 0 errors. Check it on device (installing now) — merge only on your 👍.

🤖 Generated with [Claude Code](https://claude.com/claude-code)