### PR TITLE
feat: quick idea recorder — capture on Home, link to a song later (#145)

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -32,6 +32,7 @@ import '../screens/login_screen.dart';
 import '../screens/main_shell.dart';
 import '../screens/metronome_screen.dart';
 import '../screens/practice_screen.dart';
+import '../screens/recorder_screen.dart';
 import '../screens/profile_screen.dart';
 import '../screens/setlists/create_setlist_screen.dart';
 import '../screens/setlists/setlist_view_screen.dart';
@@ -542,6 +543,17 @@ List<RouteBase> _buildAppRoutes() {
       builder: (context, state) {
         AnalyticsService.logToolOpened(tool: 'practice');
         return const PracticeScreen();
+      },
+    ),
+    GoRoute(
+      path: '/main/recorder',
+      name: 'recorder',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) {
+        AnalyticsService.logToolOpened(tool: 'recorder');
+        return RecorderScreen(
+          autoStart: state.uri.queryParameters['autostart'] == '1',
+        );
       },
     ),
     GoRoute(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../providers/data/data_providers.dart';
+import '../services/idea_recorder.dart';
 import '../utils/analytics_debug.dart';
 import '../widgets/dashboard_grid.dart';
 import '../widgets/practice_dashboard_card.dart';
@@ -58,43 +59,48 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       greetingCard: const PracticeDashboardCard(),
       statistics: const [],
       quickActions: [
-            QuickActionButton(
-              icon: Icons.add,
-              label: 'Song',
-              onTap: () => context.goNamed('add-song'),
-            ),
-            QuickActionButton(
-              icon: Icons.group_add,
-              label: 'Band',
-              onTap: () => context.goNamed('create-band'),
-            ),
-            QuickActionButton(
-              icon: Icons.playlist_add,
-              label: 'Setlist',
-              onTap: () => context.goNamed('create-setlist'),
-            ),
-            QuickActionButton(
-              icon: Icons.menu_book,
-              label: 'Practice',
-              onTap: () => context.pushNamed('practice'),
-            ),
-          ],
-          tools: [
-            ToolButton(
-              icon: Icons.tune,
-              label: 'Tuner',
-              onTap: () => context.pushNamed('tuner'),
-            ),
-            ToolButton(
-              icon: Icons.speed,
-              label: 'Metronome',
-              onTap: () => context.pushNamed('metronome'),
-            ),
-            ToolButton(
-              icon: Icons.event,
-              label: 'Rehearsals',
-              onTap: () => _openRehearsals(context, ref),
-            ),
+        QuickActionButton(
+          icon: Icons.add,
+          label: 'Song',
+          onTap: () => context.goNamed('add-song'),
+        ),
+        QuickActionButton(
+          icon: Icons.group_add,
+          label: 'Band',
+          onTap: () => context.goNamed('create-band'),
+        ),
+        QuickActionButton(
+          icon: Icons.playlist_add,
+          label: 'Setlist',
+          onTap: () => context.goNamed('create-setlist'),
+        ),
+        QuickActionButton(
+          icon: Icons.menu_book,
+          label: 'Practice',
+          onTap: () => context.pushNamed('practice'),
+        ),
+      ],
+      tools: [
+        ToolButton(
+          icon: Icons.tune,
+          label: 'Tuner',
+          onTap: () => context.pushNamed('tuner'),
+        ),
+        ToolButton(
+          icon: Icons.speed,
+          label: 'Metronome',
+          onTap: () => context.pushNamed('metronome'),
+        ),
+        ToolButton(
+          icon: Icons.event,
+          label: 'Rehearsals',
+          onTap: () => _openRehearsals(context, ref),
+        ),
+        ToolButton(
+          icon: Icons.mic,
+          label: 'Record idea',
+          onTap: () => captureIdea(context, ref),
+        ),
       ],
     );
   }
@@ -140,5 +146,4 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ),
     );
   }
-
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../providers/data/data_providers.dart';
-import '../services/idea_recorder.dart';
 import '../utils/analytics_debug.dart';
 import '../widgets/dashboard_grid.dart';
 import '../widgets/practice_dashboard_card.dart';
@@ -74,10 +73,14 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           label: 'Setlist',
           onTap: () => context.goNamed('create-setlist'),
         ),
+        // One tap, recording already running (#145 feedback).
         QuickActionButton(
-          icon: Icons.menu_book,
-          label: 'Practice',
-          onTap: () => context.pushNamed('practice'),
+          icon: Icons.mic,
+          label: 'Audio note',
+          onTap: () => context.pushNamed(
+            'recorder',
+            queryParameters: {'autostart': '1'},
+          ),
         ),
       ],
       tools: [
@@ -97,11 +100,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           onTap: () => _openRehearsals(context, ref),
         ),
         ToolButton(
-          icon: Icons.mic,
-          label: 'Record idea',
-          onTap: () => captureIdea(context, ref),
+          icon: Icons.graphic_eq,
+          label: 'Recorder',
+          onTap: () => context.pushNamed('recorder'),
         ),
       ],
+      fullWidthTool: ToolButton(
+        icon: Icons.menu_book,
+        label: 'Practice',
+        onTap: () => context.pushNamed('practice'),
+      ),
     );
   }
 

--- a/lib/screens/practice_screen.dart
+++ b/lib/screens/practice_screen.dart
@@ -4,10 +4,14 @@ import 'package:go_router/go_router.dart';
 
 import '../models/metronome_session.dart';
 import '../models/song.dart';
+import '../models/song_lab.dart';
 import '../providers/data/data_providers.dart';
 import '../providers/homework_provider.dart';
 import '../providers/practice_stats_provider.dart';
+import '../screens/songs/components/lab_recording_sheet.dart';
+import '../services/idea_recorder.dart';
 import '../theme/mono_pulse_theme.dart';
+import '../utils/snackbar.dart';
 import '../widgets/practice_dashboard_card.dart';
 import '../widgets/tools/tool_scaffold.dart';
 
@@ -51,6 +55,8 @@ class PracticeScreen extends ConsumerWidget {
           else
             for (final item in homework.take(10)) _homeworkRow(context, item),
           const SizedBox(height: MonoPulseSpacing.lg),
+          _IdeasSection(songs: songs),
+          const SizedBox(height: MonoPulseSpacing.lg),
           _sectionTitle(context, 'Quick start'),
           Row(
             children: [
@@ -67,6 +73,14 @@ class PracticeScreen extends ConsumerWidget {
                   onPressed: () => context.pushNamed('tuner'),
                   icon: const Icon(Icons.tune),
                   label: const Text('Tuner'),
+                ),
+              ),
+              const SizedBox(width: MonoPulseSpacing.md),
+              Expanded(
+                child: FilledButton.tonalIcon(
+                  onPressed: () => captureIdea(context, ref),
+                  icon: const Icon(Icons.mic),
+                  label: const Text('Idea'),
                 ),
               ),
             ],
@@ -137,14 +151,21 @@ class PracticeScreen extends ConsumerWidget {
     DateTime? lastDay;
     final today = DateTime.now();
     for (final s in sessions) {
-      final day = DateTime(s.startedAt.year, s.startedAt.month, s.startedAt.day);
+      final day = DateTime(
+        s.startedAt.year,
+        s.startedAt.month,
+        s.startedAt.day,
+      );
       if (day != lastDay) {
         lastDay = day;
         final label = day == DateTime(today.year, today.month, today.day)
             ? 'Today'
             : day ==
-                  DateTime(today.year, today.month, today.day)
-                      .subtract(const Duration(days: 1))
+                  DateTime(
+                    today.year,
+                    today.month,
+                    today.day,
+                  ).subtract(const Duration(days: 1))
             ? 'Yesterday'
             : '${day.day}/${day.month}/${day.year}';
         rows.add(
@@ -174,9 +195,7 @@ class PracticeScreen extends ConsumerWidget {
               color: MonoPulseColors.textSecondary,
             ),
             const SizedBox(width: MonoPulseSpacing.sm),
-            Expanded(
-              child: Text(song, overflow: TextOverflow.ellipsis),
-            ),
+            Expanded(child: Text(song, overflow: TextOverflow.ellipsis)),
             Text(
               '${PracticeDashboardCard.formatMinutes(s.elapsedSeconds)}'
               ' · ${s.startBpm} BPM',
@@ -214,9 +233,7 @@ class _TimePerSong extends StatelessWidget {
     final entries = stats.perSongSeconds.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
     final top = entries.take(3).toList();
-    final restSeconds = entries
-        .skip(3)
-        .fold<int>(0, (sum, e) => sum + e.value);
+    final restSeconds = entries.skip(3).fold<int>(0, (sum, e) => sum + e.value);
 
     String name(String id) =>
         id.isEmpty ? 'Freestyle' : titles[id] ?? 'Removed song';
@@ -279,5 +296,123 @@ class _TimePerSong extends StatelessWidget {
           ),
       ],
     );
+  }
+}
+
+/// Ideas inbox (#145): unlinked recordings captured from Home/Practice —
+/// play them and link each to a song, or delete.
+class _IdeasSection extends ConsumerWidget {
+  const _IdeasSection({required this.songs});
+
+  final List<Song> songs;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ideas =
+        ref.watch(labEntriesProvider((ideaInboxSongId, null))).asData?.value ??
+        const <SongLabEntry>[];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(bottom: MonoPulseSpacing.sm),
+          child: Text('Ideas', style: MonoPulseTypography.titleMedium),
+        ),
+        if (ideas.isEmpty)
+          Text(
+            'Riffs without a home yet — record one from Home or the Idea '
+            'button below, link it to a song when it finds one.',
+            style: MonoPulseTypography.bodySmall.copyWith(
+              color: MonoPulseColors.textSecondary,
+            ),
+          )
+        else
+          for (final idea in ideas)
+            Card(
+              margin: const EdgeInsets.only(bottom: MonoPulseSpacing.xs),
+              child: ListTile(
+                dense: true,
+                leading: const Icon(
+                  Icons.mic_outlined,
+                  color: MonoPulseColors.accentOrange,
+                ),
+                title: Text(idea.title ?? 'Idea'),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (idea.body?.isNotEmpty == true)
+                      Text(
+                        idea.body!,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    if (idea.attachmentIds.isNotEmpty)
+                      LabAudioPlayer(url: idea.attachmentIds.first),
+                  ],
+                ),
+                trailing: PopupMenuButton<String>(
+                  onSelected: (v) => switch (v) {
+                    'link' => _linkToSong(context, ref, idea),
+                    'delete' => _delete(context, ref, idea),
+                    _ => null,
+                  },
+                  itemBuilder: (_) => const [
+                    PopupMenuItem(value: 'link', child: Text('Link to song…')),
+                    PopupMenuItem(value: 'delete', child: Text('Delete')),
+                  ],
+                ),
+              ),
+            ),
+      ],
+    );
+  }
+
+  Future<void> _linkToSong(
+    BuildContext context,
+    WidgetRef ref,
+    SongLabEntry idea,
+  ) async {
+    final songId = await showModalBottomSheet<String>(
+      context: context,
+      builder: (sheetContext) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            const ListTile(title: Text('Link idea to song')),
+            for (final song in songs)
+              ListTile(
+                dense: true,
+                leading: const Icon(Icons.music_note),
+                title: Text(song.title),
+                subtitle: Text(song.artist),
+                onTap: () => Navigator.pop(sheetContext, song.id),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (songId == null || !context.mounted) return;
+    await linkIdeaToSong(ref, idea, songId: songId);
+    if (context.mounted) {
+      showAppSnackBar(context, "Idea linked — see the song's Lab timeline");
+    }
+  }
+
+  Future<void> _delete(
+    BuildContext context,
+    WidgetRef ref,
+    SongLabEntry idea,
+  ) async {
+    final repo = ref.read(labRepositoryProvider);
+    await repo.deleteEntry(ideaInboxSongId, idea.id);
+    if (context.mounted) {
+      showAppSnackBar(
+        context,
+        'Idea deleted',
+        actionLabel: 'Undo',
+        onAction: () => repo.saveEntry(idea),
+      );
+    }
   }
 }

--- a/lib/screens/practice_screen.dart
+++ b/lib/screens/practice_screen.dart
@@ -4,14 +4,10 @@ import 'package:go_router/go_router.dart';
 
 import '../models/metronome_session.dart';
 import '../models/song.dart';
-import '../models/song_lab.dart';
 import '../providers/data/data_providers.dart';
 import '../providers/homework_provider.dart';
 import '../providers/practice_stats_provider.dart';
-import '../screens/songs/components/lab_recording_sheet.dart';
-import '../services/idea_recorder.dart';
 import '../theme/mono_pulse_theme.dart';
-import '../utils/snackbar.dart';
 import '../widgets/practice_dashboard_card.dart';
 import '../widgets/tools/tool_scaffold.dart';
 
@@ -55,8 +51,6 @@ class PracticeScreen extends ConsumerWidget {
           else
             for (final item in homework.take(10)) _homeworkRow(context, item),
           const SizedBox(height: MonoPulseSpacing.lg),
-          _IdeasSection(songs: songs),
-          const SizedBox(height: MonoPulseSpacing.lg),
           _sectionTitle(context, 'Quick start'),
           Row(
             children: [
@@ -78,9 +72,9 @@ class PracticeScreen extends ConsumerWidget {
               const SizedBox(width: MonoPulseSpacing.md),
               Expanded(
                 child: FilledButton.tonalIcon(
-                  onPressed: () => captureIdea(context, ref),
+                  onPressed: () => context.pushNamed('recorder'),
                   icon: const Icon(Icons.mic),
-                  label: const Text('Idea'),
+                  label: const Text('Recorder'),
                 ),
               ),
             ],
@@ -296,123 +290,5 @@ class _TimePerSong extends StatelessWidget {
           ),
       ],
     );
-  }
-}
-
-/// Ideas inbox (#145): unlinked recordings captured from Home/Practice —
-/// play them and link each to a song, or delete.
-class _IdeasSection extends ConsumerWidget {
-  const _IdeasSection({required this.songs});
-
-  final List<Song> songs;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final ideas =
-        ref.watch(labEntriesProvider((ideaInboxSongId, null))).asData?.value ??
-        const <SongLabEntry>[];
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Padding(
-          padding: EdgeInsets.only(bottom: MonoPulseSpacing.sm),
-          child: Text('Ideas', style: MonoPulseTypography.titleMedium),
-        ),
-        if (ideas.isEmpty)
-          Text(
-            'Riffs without a home yet — record one from Home or the Idea '
-            'button below, link it to a song when it finds one.',
-            style: MonoPulseTypography.bodySmall.copyWith(
-              color: MonoPulseColors.textSecondary,
-            ),
-          )
-        else
-          for (final idea in ideas)
-            Card(
-              margin: const EdgeInsets.only(bottom: MonoPulseSpacing.xs),
-              child: ListTile(
-                dense: true,
-                leading: const Icon(
-                  Icons.mic_outlined,
-                  color: MonoPulseColors.accentOrange,
-                ),
-                title: Text(idea.title ?? 'Idea'),
-                subtitle: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (idea.body?.isNotEmpty == true)
-                      Text(
-                        idea.body!,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    if (idea.attachmentIds.isNotEmpty)
-                      LabAudioPlayer(url: idea.attachmentIds.first),
-                  ],
-                ),
-                trailing: PopupMenuButton<String>(
-                  onSelected: (v) => switch (v) {
-                    'link' => _linkToSong(context, ref, idea),
-                    'delete' => _delete(context, ref, idea),
-                    _ => null,
-                  },
-                  itemBuilder: (_) => const [
-                    PopupMenuItem(value: 'link', child: Text('Link to song…')),
-                    PopupMenuItem(value: 'delete', child: Text('Delete')),
-                  ],
-                ),
-              ),
-            ),
-      ],
-    );
-  }
-
-  Future<void> _linkToSong(
-    BuildContext context,
-    WidgetRef ref,
-    SongLabEntry idea,
-  ) async {
-    final songId = await showModalBottomSheet<String>(
-      context: context,
-      builder: (sheetContext) => SafeArea(
-        child: ListView(
-          shrinkWrap: true,
-          children: [
-            const ListTile(title: Text('Link idea to song')),
-            for (final song in songs)
-              ListTile(
-                dense: true,
-                leading: const Icon(Icons.music_note),
-                title: Text(song.title),
-                subtitle: Text(song.artist),
-                onTap: () => Navigator.pop(sheetContext, song.id),
-              ),
-          ],
-        ),
-      ),
-    );
-    if (songId == null || !context.mounted) return;
-    await linkIdeaToSong(ref, idea, songId: songId);
-    if (context.mounted) {
-      showAppSnackBar(context, "Idea linked — see the song's Lab timeline");
-    }
-  }
-
-  Future<void> _delete(
-    BuildContext context,
-    WidgetRef ref,
-    SongLabEntry idea,
-  ) async {
-    final repo = ref.read(labRepositoryProvider);
-    await repo.deleteEntry(ideaInboxSongId, idea.id);
-    if (context.mounted) {
-      showAppSnackBar(
-        context,
-        'Idea deleted',
-        actionLabel: 'Undo',
-        onAction: () => repo.saveEntry(idea),
-      );
-    }
   }
 }

--- a/lib/screens/recorder_screen.dart
+++ b/lib/screens/recorder_screen.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/song.dart';
+import '../models/song_lab.dart';
+import '../providers/data/data_providers.dart';
+import '../services/idea_recorder.dart';
+import '../theme/mono_pulse_theme.dart';
+import '../utils/snackbar.dart';
+import 'songs/components/lab_recording_sheet.dart';
+import '../widgets/tools/tool_scaffold.dart';
+
+/// Recorder (#145): the one home for audio captures. Record on top, every
+/// unlinked take listed below — play it, link it to a song (it moves into
+/// that song's Lab timeline), or delete it. Linked recordings live in their
+/// song's Lab, not here.
+class RecorderScreen extends ConsumerStatefulWidget {
+  const RecorderScreen({this.autoStart = false, super.key});
+
+  /// Open the capture sheet immediately with recording running (the Home
+  /// "Audio note" quick action).
+  final bool autoStart;
+
+  @override
+  ConsumerState<RecorderScreen> createState() => _RecorderScreenState();
+}
+
+class _RecorderScreenState extends ConsumerState<RecorderScreen> {
+  @override
+  void initState() {
+    super.initState();
+    if (widget.autoStart) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) captureIdea(context, ref, autoStart: true);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final recordings =
+        ref.watch(labEntriesProvider((ideaInboxSongId, null))).asData?.value ??
+        const <SongLabEntry>[];
+    final songs = ref.watch(songsProvider).asData?.value ?? const <Song>[];
+
+    return ToolScreenScaffold(
+      title: 'Recorder',
+      mainWidget: ListView(
+        padding: const EdgeInsets.all(MonoPulseSpacing.lg),
+        children: [
+          FilledButton.icon(
+            style: FilledButton.styleFrom(
+              backgroundColor: MonoPulseColors.accentOrange,
+              padding: const EdgeInsets.symmetric(
+                vertical: MonoPulseSpacing.lg,
+              ),
+            ),
+            onPressed: () => captureIdea(context, ref),
+            icon: const Icon(Icons.mic),
+            label: const Text('Record'),
+          ),
+          const SizedBox(height: MonoPulseSpacing.lg),
+          Padding(
+            padding: const EdgeInsets.only(bottom: MonoPulseSpacing.sm),
+            child: Text('Recordings', style: MonoPulseTypography.titleMedium),
+          ),
+          if (recordings.isEmpty)
+            Text(
+              'Nothing here yet — hit Record and catch the riff before it '
+              'gets away. Link takes to songs later; linked ones move into '
+              "the song's Lab.",
+              style: MonoPulseTypography.bodySmall.copyWith(
+                color: MonoPulseColors.textSecondary,
+              ),
+            )
+          else
+            for (final rec in recordings)
+              _RecordingCard(recording: rec, songs: songs),
+          const SizedBox(height: 96),
+        ],
+      ),
+    );
+  }
+}
+
+/// One take: same card shape as the song library list.
+class _RecordingCard extends ConsumerWidget {
+  const _RecordingCard({required this.recording, required this.songs});
+
+  final SongLabEntry recording;
+  final List<Song> songs;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final d = recording.createdAt;
+    return Card(
+      margin: const EdgeInsets.only(bottom: MonoPulseSpacing.sm),
+      elevation: 0,
+      color: Theme.of(context).colorScheme.surface,
+      child: ListTile(
+        title: Text(
+          recording.title ?? 'Take · ${d.day}/${d.month}',
+          style: MonoPulseTypography.titleLarge.copyWith(
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${d.day}/${d.month}/${d.year}'
+              '${recording.body?.isNotEmpty == true ? ' · ${recording.body}' : ''}',
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: MonoPulseTypography.bodySmall,
+            ),
+            if (recording.attachmentIds.isNotEmpty)
+              LabAudioPlayer(url: recording.attachmentIds.first),
+          ],
+        ),
+        trailing: PopupMenuButton<String>(
+          onSelected: (v) => switch (v) {
+            'link' => _linkToSong(context, ref),
+            'delete' => _delete(context, ref),
+            _ => null,
+          },
+          itemBuilder: (_) => const [
+            PopupMenuItem(value: 'link', child: Text('Link to song…')),
+            PopupMenuItem(value: 'delete', child: Text('Delete')),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _linkToSong(BuildContext context, WidgetRef ref) async {
+    final songId = await showModalBottomSheet<String>(
+      context: context,
+      builder: (sheetContext) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            const ListTile(title: Text('Link recording to song')),
+            for (final song in songs)
+              ListTile(
+                dense: true,
+                leading: const Icon(Icons.music_note),
+                title: Text(song.title),
+                subtitle: Text(song.artist),
+                onTap: () => Navigator.pop(sheetContext, song.id),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (songId == null || !context.mounted) return;
+    await linkIdeaToSong(ref, recording, songId: songId);
+    if (context.mounted) {
+      showAppSnackBar(context, "Linked — see the song's Lab timeline");
+    }
+  }
+
+  Future<void> _delete(BuildContext context, WidgetRef ref) async {
+    final repo = ref.read(labRepositoryProvider);
+    await repo.deleteEntry(ideaInboxSongId, recording.id);
+    if (context.mounted) {
+      showAppSnackBar(
+        context,
+        'Recording deleted',
+        actionLabel: 'Undo',
+        onAction: () => repo.saveEntry(recording),
+      );
+    }
+  }
+}

--- a/lib/screens/songs/components/lab_recording_sheet.dart
+++ b/lib/screens/songs/components/lab_recording_sheet.dart
@@ -27,9 +27,14 @@ class LabRecordingResult {
 
 /// Capture-or-attach sheet for Song Lab audio ideas (#69). Capture, don't
 /// edit: record / pick a file, name it, add manual timestamp notes
-/// ("00:42 good chorus entry"). No waveform, no DAW — by design.
+/// ("00:42 good chorus entry"). Live amplitude bars while recording;
+/// no playback waveform, no DAW — by design.
 class LabRecordingSheet extends StatefulWidget {
-  const LabRecordingSheet({super.key});
+  const LabRecordingSheet({this.autoStart = false, super.key});
+
+  /// Start recording as soon as the sheet opens (Home "Audio note", #145) —
+  /// silently ignored when the mic permission is denied or unavailable.
+  final bool autoStart;
 
   @override
   State<LabRecordingSheet> createState() => _LabRecordingSheetState();
@@ -43,13 +48,34 @@ class _LabRecordingSheetState extends State<LabRecordingSheet> {
   bool _recording = false;
   int _elapsed = 0;
   Timer? _ticker;
+  StreamSubscription<Amplitude>? _ampSub;
+  final List<double> _amps = [];
   Uint8List? _bytes;
   String _ext = 'm4a';
   String? _pickedName;
 
   @override
+  void initState() {
+    super.initState();
+    if (widget.autoStart && !kIsWeb) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) unawaited(_startGuarded());
+      });
+    }
+  }
+
+  Future<void> _startGuarded() async {
+    try {
+      await _toggleRecord();
+    } catch (_) {
+      // No recorder plugin (tests) or denied mic: the sheet just opens idle.
+    }
+  }
+
+  @override
   void dispose() {
     _ticker?.cancel();
+    _ampSub?.cancel();
     _recorder.dispose();
     _title.dispose();
     _notes.dispose();
@@ -60,6 +86,8 @@ class _LabRecordingSheetState extends State<LabRecordingSheet> {
     if (_recording) {
       final path = await _recorder.stop();
       _ticker?.cancel();
+      await _ampSub?.cancel();
+      _ampSub = null;
       if (path != null) {
         final bytes = await File(path).readAsBytes();
         setState(() {
@@ -77,14 +105,23 @@ class _LabRecordingSheetState extends State<LabRecordingSheet> {
     final dir = await getTemporaryDirectory();
     final path =
         '${dir.path}/lab_rec_${DateTime.now().millisecondsSinceEpoch}.m4a';
-    await _recorder.start(
-      const RecordConfig(),
-      path: path,
-    );
+    await _recorder.start(const RecordConfig(), path: path);
     _elapsed = 0;
+    _amps.clear();
     _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
       if (mounted) setState(() => _elapsed++);
     });
+    _ampSub = _recorder
+        .onAmplitudeChanged(const Duration(milliseconds: 100))
+        .listen((a) {
+          if (!mounted) return;
+          setState(() {
+            _amps.add(a.current);
+            if (_amps.length > _RecordingWavePainter.maxBars) {
+              _amps.removeAt(0);
+            }
+          });
+        });
     setState(() {
       _recording = true;
       _bytes = null;
@@ -136,10 +173,7 @@ class _LabRecordingSheetState extends State<LabRecordingSheet> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              'Audio idea',
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
+            Text('Audio idea', style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 4),
             Text(
               _statusLine,
@@ -149,6 +183,13 @@ class _LabRecordingSheetState extends State<LabRecordingSheet> {
                     : MonoPulseColors.textSecondary,
               ),
             ),
+            if (_recording) ...[
+              const SizedBox(height: MonoPulseSpacing.sm),
+              CustomPaint(
+                size: const Size(double.infinity, 36),
+                painter: _RecordingWavePainter(List.of(_amps)),
+              ),
+            ],
             const SizedBox(height: MonoPulseSpacing.md),
             Row(
               children: [
@@ -222,6 +263,36 @@ class _LabRecordingSheetState extends State<LabRecordingSheet> {
       ),
     );
   }
+}
+
+/// Rolling live-amplitude bars shown while recording. Input is dBFS from
+/// `record`'s amplitude stream (~-160..0); mapped linearly from a -60dB
+/// floor so speech/instrument levels use most of the bar height.
+class _RecordingWavePainter extends CustomPainter {
+  _RecordingWavePainter(this.amps);
+
+  static const maxBars = 48;
+  final List<double> amps;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = MonoPulseColors.accentOrange
+      ..strokeWidth = size.width / maxBars * 0.6
+      ..strokeCap = StrokeCap.round;
+    final step = size.width / maxBars;
+    final mid = size.height / 2;
+    for (var i = 0; i < amps.length; i++) {
+      final norm = ((amps[i] + 60) / 60).clamp(0.05, 1.0);
+      final h = norm * size.height / 2;
+      final x = (maxBars - amps.length + i) * step + step / 2;
+      canvas.drawLine(Offset(x, mid - h), Offset(x, mid + h), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_RecordingWavePainter oldDelegate) =>
+      oldDelegate.amps != amps;
 }
 
 /// Minimal play/pause for a recording entry — capture, don't edit (#69).

--- a/lib/screens/songs/song_lab_screen.dart
+++ b/lib/screens/songs/song_lab_screen.dart
@@ -11,7 +11,7 @@ import '../../providers/auth/auth_provider.dart';
 import '../../providers/data/data_providers.dart';
 import '../../services/analytics_service.dart';
 import '../../services/export/lab_markdown.dart';
-import '../../services/storage_service.dart';
+import '../../services/idea_recorder.dart';
 import '../../theme/mono_pulse_theme.dart';
 import '../../utils/chordpro.dart';
 import '../../utils/member_label.dart';
@@ -484,52 +484,9 @@ class _SongLabScreenState extends ConsumerState<SongLabScreen> {
     ),
   );
 
-  /// Record/attach an audio idea (#69): upload to Storage, then a
-  /// `recording` entry with the download URL as its attachment.
-  Future<void> _composeRecording() async {
-    final result = await showModalBottomSheet<LabRecordingResult>(
-      context: context,
-      isScrollControlled: true,
-      builder: (_) => const LabRecordingSheet(),
-    );
-    if (result == null || !mounted) return;
-
-    final entryId = _uuid.v4();
-    try {
-      final url = await StorageService().uploadLabAudio(
-        result.bytes,
-        bandId: widget.bandId,
-        songId: widget.song.id,
-        entryId: entryId,
-        ext: result.ext,
-      );
-      final uid = ref.read(firebaseAuthProvider).currentUser?.uid ?? '';
-      final now = DateTime.now();
-      await ref
-          .read(labRepositoryProvider)
-          .saveEntry(
-            SongLabEntry(
-              id: entryId,
-              songId: widget.song.id,
-              bandId: widget.bandId,
-              type: LabEntryType.recording,
-              title: result.title,
-              body: result.notes,
-              authorId: uid,
-              createdAt: now,
-              updatedAt: now,
-              attachmentIds: [url],
-            ),
-            bandId: widget.bandId,
-          );
-      unawaited(
-        AnalyticsService.logLabEntryAdded(type: LabEntryType.recording.name),
-      );
-    } catch (e) {
-      if (!mounted) return;
-      showAppSnackBar(context, 'Upload failed: $e');
-    }
-  }
+  /// Record/attach an audio idea (#69) — shared capture path (#145).
+  Future<void> _composeRecording() =>
+      captureIdea(context, ref, songId: widget.song.id, bandId: widget.bandId);
 
   Widget _filterRow() => Padding(
     padding: const EdgeInsets.symmetric(

--- a/lib/services/idea_recorder.dart
+++ b/lib/services/idea_recorder.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/song_lab.dart';
+import '../providers/auth/auth_provider.dart';
+import '../providers/data/data_providers.dart';
+import '../screens/songs/components/lab_recording_sheet.dart';
+import '../services/analytics_service.dart';
+import '../services/storage_service.dart';
+import '../utils/snackbar.dart';
+
+/// The virtual song id holding unlinked audio ideas (#145). The parent doc
+/// is never created, so it can't surface in the library; the deployed
+/// Firestore/Storage rules already cover the path (plain songId wildcards).
+const ideaInboxSongId = '_inbox';
+
+const _uuid = Uuid();
+
+/// One capture path for everywhere a mic button lives (#69/#145): opens the
+/// recording sheet, uploads, and saves a `recording` Lab entry — under a song
+/// when [songId] is given, else into the ideas inbox to be linked later.
+Future<void> captureIdea(
+  BuildContext context,
+  WidgetRef ref, {
+  String? songId,
+  String? bandId,
+}) async {
+  final result = await showModalBottomSheet<LabRecordingResult>(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => const LabRecordingSheet(),
+  );
+  if (result == null || !context.mounted) return;
+
+  final targetSongId = songId ?? ideaInboxSongId;
+  final entryId = _uuid.v4();
+  try {
+    final url = await StorageService().uploadLabAudio(
+      result.bytes,
+      bandId: bandId,
+      songId: targetSongId,
+      entryId: entryId,
+      ext: result.ext,
+    );
+    final uid = ref.read(firebaseAuthProvider).currentUser?.uid ?? '';
+    final now = DateTime.now();
+    await ref
+        .read(labRepositoryProvider)
+        .saveEntry(
+          SongLabEntry(
+            id: entryId,
+            songId: targetSongId,
+            bandId: bandId,
+            type: LabEntryType.recording,
+            title: result.title,
+            body: result.notes,
+            authorId: uid,
+            createdAt: now,
+            updatedAt: now,
+            attachmentIds: [url],
+          ),
+          bandId: bandId,
+        );
+    unawaited(
+      AnalyticsService.logLabEntryAdded(type: LabEntryType.recording.name),
+    );
+    if (context.mounted && songId == null) {
+      showAppSnackBar(
+        context,
+        'Idea saved — link it to a song from Practice → Ideas',
+      );
+    }
+  } catch (e) {
+    if (context.mounted) showAppSnackBar(context, 'Upload failed: $e');
+  }
+}
+
+/// Links an inbox idea to a song: same entry (and id — the Storage object
+/// name still matches) written under the target song, then removed from the
+/// inbox. `// ponytail: the audio object stays under _inbox; its URL keeps
+/// working — move Storage objects only if it ever matters.`
+Future<void> linkIdeaToSong(
+  WidgetRef ref,
+  SongLabEntry idea, {
+  required String songId,
+}) async {
+  final repo = ref.read(labRepositoryProvider);
+  final now = DateTime.now();
+  await repo.saveEntry(
+    SongLabEntry(
+      id: idea.id,
+      songId: songId,
+      type: idea.type,
+      title: idea.title,
+      body: idea.body,
+      authorId: idea.authorId,
+      createdAt: idea.createdAt,
+      updatedAt: now,
+      attachmentIds: idea.attachmentIds,
+    ),
+  );
+  await repo.deleteEntry(ideaInboxSongId, idea.id);
+}

--- a/lib/services/idea_recorder.dart
+++ b/lib/services/idea_recorder.dart
@@ -27,11 +27,12 @@ Future<void> captureIdea(
   WidgetRef ref, {
   String? songId,
   String? bandId,
+  bool autoStart = false,
 }) async {
   final result = await showModalBottomSheet<LabRecordingResult>(
     context: context,
     isScrollControlled: true,
-    builder: (_) => const LabRecordingSheet(),
+    builder: (_) => LabRecordingSheet(autoStart: autoStart),
   );
   if (result == null || !context.mounted) return;
 
@@ -70,7 +71,7 @@ Future<void> captureIdea(
     if (context.mounted && songId == null) {
       showAppSnackBar(
         context,
-        'Idea saved — link it to a song from Practice → Ideas',
+        'Saved — link it to a song from the Recorder list',
       );
     }
   } catch (e) {

--- a/lib/widgets/dashboard_grid.dart
+++ b/lib/widgets/dashboard_grid.dart
@@ -43,6 +43,7 @@ class DashboardGrid extends StatelessWidget {
     super.key,
     this.greetingCard,
     this.statisticsTitle = 'My Library',
+    this.fullWidthTool,
   });
 
   /// Greeting card widget (optional).
@@ -61,6 +62,10 @@ class DashboardGrid extends StatelessWidget {
 
   /// List of tool buttons.
   final List<ToolButton> tools;
+
+  /// Optional tool rendered as a full-width row under the tools grid
+  /// (Home's Practice entry, #145 feedback).
+  final ToolButton? fullWidthTool;
 
   @override
   Widget build(BuildContext context) {
@@ -92,7 +97,11 @@ class DashboardGrid extends StatelessWidget {
                       ..._statisticsSection(context, breakpoint),
                       if (statistics.isNotEmpty && tools.isNotEmpty)
                         const SizedBox(height: MonoPulseSpacing.xl),
-                      ..._toolsSection(context, breakpoint, constraints.maxWidth),
+                      ..._toolsSection(
+                        context,
+                        breakpoint,
+                        constraints.maxWidth,
+                      ),
                     ],
                   ),
                 ),
@@ -162,11 +171,15 @@ class DashboardGrid extends StatelessWidget {
     ScreenBreakpoint breakpoint,
     double maxWidth,
   ) {
-    if (tools.isEmpty) return const [];
+    if (tools.isEmpty && fullWidthTool == null) return const [];
     return [
       _buildSectionTitle(context, 'Tools', breakpoint),
       const SizedBox(height: MonoPulseSpacing.md),
       _buildResponsiveToolsGrid(breakpoint, maxWidth),
+      if (fullWidthTool != null) ...[
+        const SizedBox(height: MonoPulseSpacing.md),
+        SizedBox(height: _tileHeight(breakpoint), child: fullWidthTool),
+      ],
     ];
   }
 

--- a/site/content/wiki/practice.md
+++ b/site/content/wiki/practice.md
@@ -12,10 +12,11 @@ Your practice, tracked automatically — every metronome session is logged
 - **Where your time went** — this week's minutes split per song.
 - **Homework** — open tasks from your songs' [Labs](../songs/) in one list;
   tap one to jump to that song's Lab.
-- **Ideas** — riffs you recorded before they had a song (Home → Record idea,
-  or the Idea button below): play them back, then link each to a song — it
-  lands in that song's Lab timeline.
 - **Recent sessions** — the logbook: day by day, song, duration and BPM.
-- **Quick start** — jump straight into the Metronome, Tuner, or record an idea.
+- **Quick start** — jump straight into the Metronome, Tuner, or the Recorder.
+
+Recordings live in the **Recorder** (Home → Tools, or Home → Audio note for
+one-tap capture): record riffs before they have a song, play them back, and
+link each to a song — it lands in that song's Lab timeline.
 
 Coming later: exercises, goals and a fuller practice workbook.

--- a/site/content/wiki/practice.md
+++ b/site/content/wiki/practice.md
@@ -12,7 +12,10 @@ Your practice, tracked automatically — every metronome session is logged
 - **Where your time went** — this week's minutes split per song.
 - **Homework** — open tasks from your songs' [Labs](../songs/) in one list;
   tap one to jump to that song's Lab.
+- **Ideas** — riffs you recorded before they had a song (Home → Record idea,
+  or the Idea button below): play them back, then link each to a song — it
+  lands in that song's Lab timeline.
 - **Recent sessions** — the logbook: day by day, song, duration and BPM.
-- **Quick start** — jump straight into the Metronome or Tuner.
+- **Quick start** — jump straight into the Metronome, Tuner, or record an idea.
 
 Coming later: exercises, goals and a fuller practice workbook.

--- a/test/screens/home_quick_actions_test.dart
+++ b/test/screens/home_quick_actions_test.dart
@@ -102,6 +102,8 @@ void main() {
 
       expect(find.text('Quick Actions'), findsOneWidget);
       expect(find.text('Song'), findsOneWidget);
+      // #145: idea recorder lives in Tools.
+      expect(find.text('Record idea'), findsOneWidget);
     });
 
     testWidgets('routes from Home to the Add Song entry screen', (

--- a/test/screens/home_quick_actions_test.dart
+++ b/test/screens/home_quick_actions_test.dart
@@ -102,8 +102,9 @@ void main() {
 
       expect(find.text('Quick Actions'), findsOneWidget);
       expect(find.text('Song'), findsOneWidget);
-      // #145: idea recorder lives in Tools.
-      expect(find.text('Record idea'), findsOneWidget);
+      // #145: one-tap capture in Quick Actions, full Recorder in Tools.
+      expect(find.text('Audio note'), findsOneWidget);
+      expect(find.text('Recorder'), findsOneWidget);
     });
 
     testWidgets('routes from Home to the Add Song entry screen', (

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -16,7 +16,6 @@ import '../helpers/test_helpers.dart';
 
 // Test notifier that returns a specific value
 class TestAppUserNotifier extends AppUserNotifier {
-
   TestAppUserNotifier(this.mockUser);
   final AppUser? mockUser;
 
@@ -66,9 +65,7 @@ void main() {
       mockAuth = MockFirebaseAuth();
     });
 
-    testWidgets('renders home screen with dashboard grid', (
-      tester,
-    ) async {
+    testWidgets('renders home screen with dashboard grid', (tester) async {
       await pumpHomeScreen(tester, mockAuth: mockAuth);
 
       expect(find.byType(DashboardGrid), findsOneWidget);
@@ -103,11 +100,13 @@ void main() {
 
       await pumpHomeScreen(tester, mockAuth: mockAuth, user: mockUser);
 
-      expect(find.byType(ToolButton), findsNWidgets(4));
+      // 4 grid tools + the full-width Practice row (#145 rebalance).
+      expect(find.byType(ToolButton), findsNWidgets(5));
       expect(find.text('Tuner'), findsOneWidget);
       expect(find.text('Metronome'), findsOneWidget);
       expect(find.text('Rehearsals'), findsOneWidget);
-      expect(find.text('Record idea'), findsOneWidget);
+      expect(find.text('Recorder'), findsOneWidget);
+      expect(find.text('Practice'), findsOneWidget);
     });
 
     testWidgets('renders quick action buttons with correct icons', (
@@ -123,9 +122,7 @@ void main() {
       expect(find.byIcon(Icons.menu_book), findsOneWidget);
     });
 
-    testWidgets('renders tool buttons with correct icons', (
-      tester,
-    ) async {
+    testWidgets('renders tool buttons with correct icons', (tester) async {
       final mockUser = MockDataHelper.createMockAppUser();
 
       await pumpHomeScreen(tester, mockAuth: mockAuth, user: mockUser);

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -103,10 +103,11 @@ void main() {
 
       await pumpHomeScreen(tester, mockAuth: mockAuth, user: mockUser);
 
-      expect(find.byType(ToolButton), findsNWidgets(3));
+      expect(find.byType(ToolButton), findsNWidgets(4));
       expect(find.text('Tuner'), findsOneWidget);
       expect(find.text('Metronome'), findsOneWidget);
       expect(find.text('Rehearsals'), findsOneWidget);
+      expect(find.text('Record idea'), findsOneWidget);
     });
 
     testWidgets('renders quick action buttons with correct icons', (

--- a/test/screens/practice_ideas_test.dart
+++ b/test/screens/practice_ideas_test.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+
+import 'package:flowgroove/models/metronome_session.dart';
+import 'package:flowgroove/models/song.dart';
+import 'package:flowgroove/models/song_lab.dart';
+import 'package:flowgroove/providers/data/data_providers.dart';
+import 'package:flowgroove/providers/homework_provider.dart';
+import 'package:flowgroove/providers/practice_stats_provider.dart';
+import 'package:flowgroove/repositories/firestore_lab_repository.dart';
+import 'package:flowgroove/screens/practice_screen.dart';
+import 'package:flowgroove/services/idea_recorder.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/mocks.mocks.dart';
+
+class _InMemoryLabRepo extends FirestoreLabRepository {
+  _InMemoryLabRepo()
+    : super(firestore: MockFirebaseFirestore(), auth: MockFirebaseAuth());
+
+  // Entries keyed by songId — the inbox and linked songs are separate lists,
+  // matching the Firestore subcollection layout.
+  final entries = <String, List<SongLabEntry>>{};
+  final _controllers = <String, StreamController<List<SongLabEntry>>>{};
+
+  StreamController<List<SongLabEntry>> _controller(String songId) =>
+      _controllers.putIfAbsent(
+        songId,
+        () => StreamController<List<SongLabEntry>>.broadcast(),
+      );
+
+  void _emit(String songId) =>
+      _controller(songId).add(List.of(entries[songId] ?? const []));
+
+  @override
+  Stream<List<SongLabEntry>> watchEntries(String songId, {String? bandId}) {
+    scheduleMicrotask(() => _emit(songId));
+    return _controller(songId).stream;
+  }
+
+  @override
+  Future<void> saveEntry(SongLabEntry entry, {String? bandId}) async {
+    final list = entries.putIfAbsent(entry.songId, () => []);
+    list.removeWhere((e) => e.id == entry.id);
+    list.insert(0, entry);
+    _emit(entry.songId);
+  }
+
+  @override
+  Future<void> deleteEntry(
+    String songId,
+    String entryId, {
+    String? bandId,
+  }) async {
+    entries[songId]?.removeWhere((e) => e.id == entryId);
+    _emit(songId);
+  }
+}
+
+void main() {
+  final song = Song(
+    id: 's1',
+    title: 'Hey Joe',
+    artist: 'Jimi Hendrix',
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
+
+  SongLabEntry idea() => SongLabEntry(
+    id: 'idea1',
+    songId: ideaInboxSongId,
+    type: LabEntryType.recording,
+    title: 'Riff in E',
+    body: 'hummed on the bus',
+    authorId: 'u1',
+    createdAt: DateTime(2026, 7, 16),
+    updatedAt: DateTime(2026, 7, 16),
+  );
+
+  Future<_InMemoryLabRepo> pump(
+    WidgetTester tester, {
+    List<SongLabEntry> inbox = const [],
+  }) async {
+    final repo = _InMemoryLabRepo();
+    for (final e in inbox) {
+      repo.entries.putIfAbsent(e.songId, () => []).add(e);
+    }
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          labRepositoryProvider.overrideWithValue(repo),
+          songsProvider.overrideWith((ref) => Stream.value([song])),
+          practiceStatsProvider.overrideWith(
+            (ref) async => PracticeStats.empty,
+          ),
+          practiceSessionsProvider.overrideWith(
+            (ref) async => <MetronomeSession>[],
+          ),
+          myHomeworkProvider.overrideWith((ref) async => <HomeworkItem>[]),
+        ],
+        child: const MaterialApp(home: PracticeScreen()),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    return repo;
+  }
+
+  group('Practice Ideas inbox (#145)', () {
+    testWidgets('quiet empty state when no ideas', (tester) async {
+      await pump(tester);
+
+      expect(find.text('Ideas'), findsOneWidget);
+      expect(find.textContaining('Riffs without a home'), findsOneWidget);
+    });
+
+    testWidgets('renders an inbox idea', (tester) async {
+      await pump(tester, inbox: [idea()]);
+
+      expect(find.text('Riff in E'), findsOneWidget);
+      expect(find.text('hummed on the bus'), findsOneWidget);
+    });
+
+    testWidgets('link to song moves the entry out of the inbox', (
+      tester,
+    ) async {
+      final repo = await pump(tester, inbox: [idea()]);
+
+      await tester.ensureVisible(find.byIcon(Icons.mic_outlined));
+      await tester.tap(
+        find.descendant(
+          of: find.widgetWithText(ListTile, 'Riff in E'),
+          matching: find.byType(PopupMenuButton<String>),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Link to song…'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Hey Joe'));
+      await tester.pumpAndSettle();
+
+      expect(repo.entries[ideaInboxSongId], isEmpty);
+      expect(repo.entries['s1'], hasLength(1));
+      expect(repo.entries['s1']!.single.id, 'idea1');
+      expect(repo.entries['s1']!.single.title, 'Riff in E');
+      expect(find.textContaining('Idea linked'), findsOneWidget);
+    });
+
+    testWidgets('delete removes the idea with an Undo', (tester) async {
+      final repo = await pump(tester, inbox: [idea()]);
+
+      await tester.ensureVisible(find.byIcon(Icons.mic_outlined));
+      await tester.tap(
+        find.descendant(
+          of: find.widgetWithText(ListTile, 'Riff in E'),
+          matching: find.byType(PopupMenuButton<String>),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      expect(repo.entries[ideaInboxSongId], isEmpty);
+
+      await tester.tap(find.text('Undo'));
+      await tester.pumpAndSettle();
+      expect(repo.entries[ideaInboxSongId], hasLength(1));
+    });
+  });
+}

--- a/test/screens/recorder_screen_test.dart
+++ b/test/screens/recorder_screen_test.dart
@@ -1,13 +1,10 @@
 import 'dart:async';
 
-import 'package:flowgroove/models/metronome_session.dart';
 import 'package:flowgroove/models/song.dart';
 import 'package:flowgroove/models/song_lab.dart';
 import 'package:flowgroove/providers/data/data_providers.dart';
-import 'package:flowgroove/providers/homework_provider.dart';
-import 'package:flowgroove/providers/practice_stats_provider.dart';
 import 'package:flowgroove/repositories/firestore_lab_repository.dart';
-import 'package:flowgroove/screens/practice_screen.dart';
+import 'package:flowgroove/screens/recorder_screen.dart';
 import 'package:flowgroove/services/idea_recorder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -67,8 +64,8 @@ void main() {
     updatedAt: DateTime(2026),
   );
 
-  SongLabEntry idea() => SongLabEntry(
-    id: 'idea1',
+  SongLabEntry recording() => SongLabEntry(
+    id: 'rec1',
     songId: ideaInboxSongId,
     type: LabEntryType.recording,
     title: 'Riff in E',
@@ -91,15 +88,8 @@ void main() {
         overrides: [
           labRepositoryProvider.overrideWithValue(repo),
           songsProvider.overrideWith((ref) => Stream.value([song])),
-          practiceStatsProvider.overrideWith(
-            (ref) async => PracticeStats.empty,
-          ),
-          practiceSessionsProvider.overrideWith(
-            (ref) async => <MetronomeSession>[],
-          ),
-          myHomeworkProvider.overrideWith((ref) async => <HomeworkItem>[]),
         ],
-        child: const MaterialApp(home: PracticeScreen()),
+        child: const MaterialApp(home: RecorderScreen()),
       ),
     );
     await tester.pump();
@@ -107,33 +97,28 @@ void main() {
     return repo;
   }
 
-  group('Practice Ideas inbox (#145)', () {
-    testWidgets('quiet empty state when no ideas', (tester) async {
+  group('RecorderScreen (#145)', () {
+    testWidgets('record button on top, quiet empty state', (tester) async {
       await pump(tester);
 
-      expect(find.text('Ideas'), findsOneWidget);
-      expect(find.textContaining('Riffs without a home'), findsOneWidget);
+      expect(find.text('Record'), findsOneWidget);
+      expect(find.text('Recordings'), findsOneWidget);
+      expect(find.textContaining('Nothing here yet'), findsOneWidget);
     });
 
-    testWidgets('renders an inbox idea', (tester) async {
-      await pump(tester, inbox: [idea()]);
+    testWidgets('lists inbox recordings as cards', (tester) async {
+      await pump(tester, inbox: [recording()]);
 
       expect(find.text('Riff in E'), findsOneWidget);
-      expect(find.text('hummed on the bus'), findsOneWidget);
+      expect(find.textContaining('hummed on the bus'), findsOneWidget);
     });
 
-    testWidgets('link to song moves the entry out of the inbox', (
+    testWidgets('link to song moves the recording out of the inbox', (
       tester,
     ) async {
-      final repo = await pump(tester, inbox: [idea()]);
+      final repo = await pump(tester, inbox: [recording()]);
 
-      await tester.ensureVisible(find.byIcon(Icons.mic_outlined));
-      await tester.tap(
-        find.descendant(
-          of: find.widgetWithText(ListTile, 'Riff in E'),
-          matching: find.byType(PopupMenuButton<String>),
-        ),
-      );
+      await tester.tap(find.byType(PopupMenuButton<String>));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Link to song…'));
       await tester.pumpAndSettle();
@@ -142,21 +127,15 @@ void main() {
 
       expect(repo.entries[ideaInboxSongId], isEmpty);
       expect(repo.entries['s1'], hasLength(1));
-      expect(repo.entries['s1']!.single.id, 'idea1');
+      expect(repo.entries['s1']!.single.id, 'rec1');
       expect(repo.entries['s1']!.single.title, 'Riff in E');
-      expect(find.textContaining('Idea linked'), findsOneWidget);
+      expect(find.textContaining('Linked'), findsOneWidget);
     });
 
-    testWidgets('delete removes the idea with an Undo', (tester) async {
-      final repo = await pump(tester, inbox: [idea()]);
+    testWidgets('delete removes the recording with an Undo', (tester) async {
+      final repo = await pump(tester, inbox: [recording()]);
 
-      await tester.ensureVisible(find.byIcon(Icons.mic_outlined));
-      await tester.tap(
-        find.descendant(
-          of: find.widgetWithText(ListTile, 'Riff in E'),
-          matching: find.byType(PopupMenuButton<String>),
-        ),
-      );
+      await tester.tap(find.byType(PopupMenuButton<String>));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Delete'));
       await tester.pumpAndSettle();


### PR DESCRIPTION
## What

Beta idea: musicians catch riffs before they know which song they belong to. Recording used to require picking a song first (Song Lab). Now:

- **Home → Tools → Record idea** (and Practice → Quick start → Idea): opens the same recording sheet, saves the take into an **Ideas inbox** — `users/{uid}/songs/_inbox/labEntries` (virtual parent doc: never created, so `_inbox` can't appear in the library; deployed Firestore/Storage rules already cover the path — **zero rules changes**).
- **Practice → Ideas section**: play back each idea, **Link to song…** (picker; the entry moves under the chosen song with the same id, so the Storage object name still matches and the URL keeps working), or Delete with Undo.
- One capture path: `lib/services/idea_recorder.dart` — Song Lab's record button now delegates to it too.

## Tests

- `practice_ideas_test.dart`: empty state, inbox render, link-to-song moves the entry (inbox emptied, lands under target song), delete + Undo restore.
- Home tests updated: 4 tool buttons incl. 'Record idea'.
- Full suite green (2008 passing).

Refs #145 — close manually after the on-device pass (record on Home → shows in Practice Ideas → link → appears in the song's Lab timeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)