### PR TITLE
fix: Songs ⋮ menu lost after deep mount into the branch; Lab record chip discoverability

### DIFF
--- a/lib/screens/songs/song_lab_screen.dart
+++ b/lib/screens/songs/song_lab_screen.dart
@@ -469,17 +469,23 @@ class _SongLabScreenState extends ConsumerState<SongLabScreen> {
     child: Wrap(
       spacing: MonoPulseSpacing.sm,
       children: [
+        // Record leads the row (device feedback: users looked for it and
+        // missed it as the trailing chip) — first slot, accent mic.
+        ActionChip(
+          avatar: Icon(
+            _typeIcons[LabEntryType.recording],
+            size: 18,
+            color: MonoPulseColors.accentOrange,
+          ),
+          label: const Text('+ Record'),
+          onPressed: _composeRecording,
+        ),
         for (final t in _quickTypes)
           ActionChip(
             avatar: Icon(_typeIcons[t], size: 18),
             label: Text('+ ${_typeLabel(t)}'),
             onPressed: () => _compose(t),
           ),
-        ActionChip(
-          avatar: Icon(_typeIcons[LabEntryType.recording], size: 18),
-          label: const Text('+ Recording'),
-          onPressed: _composeRecording,
-        ),
       ],
     ),
   );

--- a/lib/widgets/menu_items_scope.dart
+++ b/lib/widgets/menu_items_scope.dart
@@ -136,11 +136,13 @@ typedef _StackEntry = ({Object token, String location, MenuScopeData data});
 /// location for as long as this widget is in the tree, and exposes it locally
 /// as a [MenuItemsScope].
 ///
-/// The location key is captured ONCE, on first `didChangeDependencies`
-/// (`GoRouterState.of(context).uri`) — never re-read on rebuild. A kept-alive
-/// branch-root screen that rebuilds while a child route is on top would
-/// otherwise see the CHILD's uri in its own `GoRouterState` and clobber the
-/// child's registry entry with the root's data.
+/// The location key is `GoRouterState.of(context).matchedLocation` — the
+/// route's OWN matched path, resolved per page. NOT `uri`: `uri` is always
+/// the full current location, so a branch root that first mounts UNDER a
+/// child route (deep navigation into a not-yet-visited tab, e.g. Practice →
+/// a song's Lab before ever opening the Songs tab) would register under the
+/// child's uri and the shell's root-menu lookup would miss forever — the ⋮
+/// sheet then shows only the global Profile/Settings rows.
 ///
 /// Writes are deferred to a post-frame callback (never done synchronously
 /// during build/lifecycle) — mutating shared state that an ancestor (the
@@ -174,7 +176,7 @@ class _MenuScopePublisherState extends State<MenuScopePublisher> {
     super.didChangeDependencies();
     if (_location == null) {
       try {
-        _location = GoRouterState.of(context).uri.toString();
+        _location = GoRouterState.of(context).matchedLocation;
       } catch (_) {
         // Not under a GoRoute (imperative push, widget test) — no registry
         // publication; the shell can't see this screen anyway.

--- a/test/screens/songs/songs_list_screen_test.dart
+++ b/test/screens/songs/songs_list_screen_test.dart
@@ -371,6 +371,34 @@ void main() {
       expect(find.text('Try searching for "missing"'), findsOneWidget);
     });
 
+    testWidgets(
+      'root menu survives the branch first mounting under a child route',
+      (tester) async {
+        // Regression (device 2026-07-16): entering the songs branch for the
+        // first time BELOW its root (e.g. Practice → a song's Lab) made the
+        // songs root register its menu under the child's uri — the Songs
+        // tab's ⋮ then showed only the global Profile/Settings rows.
+        await pumpRoutedTestApp(
+          tester,
+          initialLocation: '/main/songs/add', // deep entry, root never visited
+          overrides: overridesFor(
+            songs: Stream<List<Song>>.value([createTestSong()]),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('route:add-song'), findsOneWidget);
+
+        // Back to the songs root, open the bottom-bar menu.
+        await tester.tap(find.byIcon(Icons.arrow_back));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.more_horiz));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Find duplicates'), findsOneWidget);
+        expect(find.text('Browse catalog'), findsOneWidget);
+      },
+    );
+
     testWidgets('navigates to add song from FAB', (tester) async {
       final router = await pumpRoutedTestApp(
         tester,


### PR DESCRIPTION
Both from the 2026-07-16 on-device pass of the preview build.

## 1. Branch-root menu lost (the "only Profile and Settings" bug)

**Repro:** fresh app start → Practice → open a song's Lab (or any deep entry into a not-yet-visited branch) → Songs tab → ⋮ shows only the global Profile/Settings rows; Find duplicates / Browse catalog / CSV import-export are gone until app restart.

**Cause:** `MenuScopePublisher` keyed `MenuScopeRegistry` by `GoRouterState.uri` — always the FULL current location. A branch root first mounted UNDER a child route captured the child's uri (capture-once by design), so `forLocation('/main/songs')` missed forever.

**Fix:** key by `matchedLocation` — go_router resolves it per page, so a screen always registers under its own route path no matter what's on top. This also removes the failure mode the capture-once hack guarded against.

**Proof:** new regression test (deep entry at `/main/songs/add` → back → menu contents) fails on the old line, passes on the fix. Full suite green (2005).

## 2. Song Lab record chip (#69 feedback)

Tester couldn't find where to record inside the Lab — '+ Recording' was the trailing fifth chip. Now **first** in the quick-add row as **+ Record** with an accent-orange mic icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)